### PR TITLE
add estimated reading time to blog data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# GoBlog — Claude Instructions
+
+## Documentation
+
+All API changes (new exported types, functions, options, flags, or fields) must include corresponding documentation updates: godoc comments on the new symbols, relevant sections in `README.md`, and any package-level `doc.go` entries that reference available options or features.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ goblog serve posts/ --port 8080
 |---|---|---|---|
 | `--raw` | `-r` | `false` | Output raw HTML without template wrapping |
 | `--disable-tags` | `-T` | `false` | Disable tag tracking and tag page generation |
+| `--disable-reading-time` | | `false` | Disable reading time estimation on posts |
 | `--root-path` | `-p` | `/` | Blog root path for subdirectory deployment |
 | `--template-dir` | `-t` | built-in | Path to a custom template directory |
 
@@ -139,6 +140,7 @@ goblog serve posts/ --port 8080
 | `--port` | `-P` | `8080` | TCP port to listen on |
 | `--host` | `-H` | all interfaces | Host address to bind to |
 | `--disable-tags` | `-T` | `false` | Disable tag tracking and tag page generation |
+| `--disable-reading-time` | | `false` | Disable reading time estimation on posts |
 | `--root-path` | `-p` | `/` | Blog root path for subdirectory deployment |
 | `--template-dir` | `-t` | built-in | Path to a custom template directory |
 
@@ -510,7 +512,7 @@ To use the built-in templates instead, replace `os.DirFS("./mytheme")` with
 | [`pkg/generator`](https://pkg.go.dev/github.com/harrydayexe/GoBlog/v2/pkg/generator) | Convert a directory of posts into a `GeneratedBlog` in memory |
 | [`pkg/outputter`](https://pkg.go.dev/github.com/harrydayexe/GoBlog/v2/pkg/outputter) | Write a `GeneratedBlog` to disk; implement `Outputter` for custom destinations |
 | [`pkg/server`](https://pkg.go.dev/github.com/harrydayexe/GoBlog/v2/pkg/server) | HTTP server with atomic live-reload via `Server.UpdatePosts` |
-| [`pkg/config`](https://pkg.go.dev/github.com/harrydayexe/GoBlog/v2/pkg/config) | Functional options: `WithRawOutput`, `WithDisableTags`, `WithSiteTitle`, `WithBlogRoot`, `WithEnvironment`, `WithPort`, `WithHost`, `WithMiddleware` |
+| [`pkg/config`](https://pkg.go.dev/github.com/harrydayexe/GoBlog/v2/pkg/config) | Functional options: `WithRawOutput`, `WithDisableTags`, `WithDisableReadingTime`, `WithSiteTitle`, `WithBlogRoot`, `WithEnvironment`, `WithPort`, `WithHost`, `WithMiddleware` |
 | [`pkg/templates`](https://pkg.go.dev/github.com/harrydayexe/GoBlog/v2/pkg/templates) | Embedded default templates (`templates.Default`) |
 
 ### Site title

--- a/README.md
+++ b/README.md
@@ -330,6 +330,39 @@ The `BaseData` struct passed to all templates includes a `TagsEnabled bool` fiel
 
 The built-in templates already respect this field. If you provide custom templates that unconditionally render tag links, those links will still appear even when `--disable-tags` is set — update them to gate on `{{.TagsEnabled}}`.
 
+### Reading Time
+
+By default, GoBlog computes an estimated reading time for each post and the default templates display it inline next to the post date (e.g. `March 15, 2026 · 5 min read`). Reading time is calculated by stripping HTML tags from the rendered content, counting whitespace-separated words, and dividing by **220 WPM** with ceiling rounding and a 1-minute floor.
+
+#### Using Disable Reading Time with the CLI
+
+```bash
+# Generate without reading time annotations
+goblog generate posts/ output/ --disable-reading-time
+
+# Also works with serve
+goblog serve posts/ --disable-reading-time
+```
+
+When reading time is disabled:
+- `Post.ReadingTimeMinutes` is left at zero for all posts
+- The default templates suppress the `· N min read` annotation (they guard it with `{{if .Post.ReadingTimeMinutes}}`)
+- No other output changes — posts, index, and tag pages are unaffected
+
+#### Using Disable Reading Time with the Go API
+
+```go
+gen := generator.New(fsys, renderer, config.WithDisableReadingTime())
+```
+
+#### Custom Templates and ReadingTimeMinutes
+
+The `Post` struct includes a `ReadingTimeMinutes int` field (zero when disabled). Custom templates can render it conditionally:
+
+```html
+{{if .Post.ReadingTimeMinutes}} · {{.Post.ReadingTimeMinutes}} min read{{end}}
+```
+
 ### Blog Root Configuration
 
 When deploying your blog at a subdirectory rather than the root of your domain (e.g., `example.com/blog/` instead of `example.com/`), you need to configure the blog root path. This ensures all generated links in templates use the correct base path.
@@ -453,7 +486,7 @@ page-specific fields:
 
 | Template | Data struct | Extra fields |
 |---|---|---|
-| `pages/post.tmpl` | [`PostPageData`](https://pkg.go.dev/github.com/harrydayexe/GoBlog/v2/pkg/models#PostPageData) | `.Post *Post` |
+| `pages/post.tmpl` | [`PostPageData`](https://pkg.go.dev/github.com/harrydayexe/GoBlog/v2/pkg/models#PostPageData) | `.Post *Post` (includes `.Post.ReadingTimeMinutes int`) |
 | `pages/index.tmpl` | [`IndexPageData`](https://pkg.go.dev/github.com/harrydayexe/GoBlog/v2/pkg/models#IndexPageData) | `.Posts PostList`, `.TotalPosts int` |
 | `pages/tag.tmpl` | [`TagPageData`](https://pkg.go.dev/github.com/harrydayexe/GoBlog/v2/pkg/models#TagPageData) | `.Tag string`, `.Posts []*Post`, `.PostCount int` — not rendered when `--disable-tags` is set |
 | `pages/tags-index.tmpl` | [`TagsIndexPageData`](https://pkg.go.dev/github.com/harrydayexe/GoBlog/v2/pkg/models#TagsIndexPageData) | `.Tags []TagInfo`, `.TotalTags int` — not rendered when `--disable-tags` is set |

--- a/internal/generator/command.go
+++ b/internal/generator/command.go
@@ -46,5 +46,10 @@ var GeneratorCommand cli.Command = cli.Command{
 			Usage:   "disable tag tracking and tag page generation",
 			Value:   false,
 		},
+		&cli.BoolFlag{
+			Name:  DisableReadingTimeFlagName,
+			Usage: "disable reading time estimation on posts",
+			Value: false,
+		},
 	},
 }

--- a/internal/generator/flagConsts.go
+++ b/internal/generator/flagConsts.go
@@ -17,3 +17,6 @@ const BlogRootFlagName = "root-path"
 
 // DisableTagsFlagName is the CLI flag name for disabling tag page generation.
 const DisableTagsFlagName = "disable-tags"
+
+// DisableReadingTimeFlagName is the CLI flag name for disabling reading time estimation.
+const DisableReadingTimeFlagName = "disable-reading-time"

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -50,6 +50,10 @@ func NewGeneratorCommand(ctx context.Context, c *cli.Command) error {
 		opts = append(opts, config.WithDisableTags())
 	}
 
+	if c.Bool(DisableReadingTimeFlagName) {
+		opts = append(opts, config.WithDisableReadingTime())
+	}
+
 	templateDirPath := c.String(TemplateDirFlagName)
 	var templateDir fs.FS
 	if templateDirPath == "" {

--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -46,5 +46,10 @@ var ServeCommand cli.Command = cli.Command{
 			Usage:   "disable tag tracking and tag page generation",
 			Value:   false,
 		},
+		&cli.BoolFlag{
+			Name:  DisableReadingTimeFlagName,
+			Usage: "disable reading time estimation on posts",
+			Value: false,
+		},
 	},
 }

--- a/internal/server/flagConsts.go
+++ b/internal/server/flagConsts.go
@@ -17,3 +17,6 @@ const BlogRootFlagName = "root-path"
 
 // DisableTagsFlagName is the CLI flag name for disabling tag page generation.
 const DisableTagsFlagName = "disable-tags"
+
+// DisableReadingTimeFlagName is the CLI flag name for disabling reading time estimation.
+const DisableReadingTimeFlagName = "disable-reading-time"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,6 +37,10 @@ func NewServeCommand(ctx context.Context, c *cli.Command) error {
 	if c.Bool(DisableTagsFlagName) {
 		cfg.Gen = append(cfg.Gen, config.WithDisableTags())
 	}
+
+	if c.Bool(DisableReadingTimeFlagName) {
+		cfg.Gen = append(cfg.Gen, config.WithDisableReadingTime())
+	}
 	cfg.Server = append(cfg.Server, config.WithPort(c.Int(PortFlagName)))
 
 	if host := c.String(HostFlagName); host != "" {

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -32,6 +32,11 @@
 // does not register /tags routes. Unlike WithRawOutput(), posts and the index
 // page are still rendered with full templates.
 //
+// WithDisableReadingTime() disables estimated reading time on posts. When
+// enabled, Post.ReadingTimeMinutes is left at zero and the default templates
+// suppress the "· N min read" annotation next to each post date. Reading time
+// is enabled by default (220 WPM, rounded up, 1-minute minimum).
+//
 // WithSiteTitle(title string) sets the site title used in generated HTML
 // pages and templates.
 //

--- a/pkg/config/generatorOption.go
+++ b/pkg/config/generatorOption.go
@@ -9,14 +9,15 @@ package config
 //
 // This type should not be constructed directly by users. Instead, use the
 // provided option functions like WithRawOutput(), WithDisableTags(),
-// WithSiteTitle(), WithEnvironment(), and WithBaseOption().
+// WithDisableReadingTime(), WithSiteTitle(), WithEnvironment(), and WithBaseOption().
 type GeneratorOption struct {
 	BaseOption
 
-	WithRawOutputFunc   func(v *RawOutput)
-	WithDisableTagsFunc func(v *DisableTags)
-	WithSiteTitleFunc   func(v *SiteTitle)
-	WithEnvironmentFunc func(v *Environment)
+	WithRawOutputFunc          func(v *RawOutput)
+	WithDisableTagsFunc        func(v *DisableTags)
+	WithDisableReadingTimeFunc func(v *DisableReadingTime)
+	WithSiteTitleFunc          func(v *SiteTitle)
+	WithEnvironmentFunc        func(v *Environment)
 }
 
 // WithBaseOption wraps a BaseOption as a GeneratorOption so it can be passed
@@ -115,6 +116,47 @@ func (o DisableTags) AsOption() GeneratorOption {
 	}
 	return GeneratorOption{
 		WithDisableTagsFunc: func(v *DisableTags) {
+			v.Disable = false
+		},
+	}
+}
+
+// DisableReadingTime is a configuration type that controls whether estimated
+// reading times are computed and surfaced on post pages.
+//
+// When Disable is true:
+//   - Post.ReadingTimeMinutes is left at zero for all posts
+//   - The default templates omit the "· N min read" annotation next to the date
+//
+// This type is typically embedded in generator configuration structs and should
+// be set using the WithDisableReadingTime() option function.
+type DisableReadingTime struct{ Disable bool }
+
+// WithDisableReadingTime returns a GeneratorOption that disables reading time
+// estimation on posts.
+//
+// When applied to a generator, Post.ReadingTimeMinutes will remain zero for all
+// posts. The default templates guard the "· N min read" annotation with
+// {{if .Post.ReadingTimeMinutes}}, so setting this option suppresses the display
+// without requiring template changes.
+//
+// Example usage:
+//
+//	gen := generator.New(fsys, renderer, config.WithDisableReadingTime())
+func WithDisableReadingTime() GeneratorOption {
+	return GeneratorOption{
+		WithDisableReadingTimeFunc: func(v *DisableReadingTime) {
+			v.Disable = true
+		},
+	}
+}
+
+func (o DisableReadingTime) AsOption() GeneratorOption {
+	if o.Disable {
+		return WithDisableReadingTime()
+	}
+	return GeneratorOption{
+		WithDisableReadingTimeFunc: func(v *DisableReadingTime) {
 			v.Disable = false
 		},
 	}

--- a/pkg/generator/generatedSite.go
+++ b/pkg/generator/generatedSite.go
@@ -34,6 +34,14 @@ package generator
 //
 // This mode is useful when the blog content is not taxonomy-driven or when a
 // custom navigation structure is used in place of GoBlog's built-in tag pages.
+//
+// # Disable Reading Time Mode
+//
+// When the generator is configured with config.WithDisableReadingTime(), the
+// Post.ReadingTimeMinutes field is left at zero for all posts. The default
+// templates guard the "· N min read" annotation with
+// {{if .Post.ReadingTimeMinutes}}, so the annotation is simply omitted without
+// any other changes to the output structure.
 type GeneratedBlog struct {
 	Posts     map[string][]byte // Posts maps a slug to raw HTML bytes for each post
 	Index     []byte            // Index contains the raw HTML for the blog index page

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -25,6 +25,7 @@ type Generator struct {
 
 	config.RawOutput
 	config.DisableTags
+	config.DisableReadingTime
 	config.SiteTitle
 	config.BlogRoot
 	config.Environment
@@ -38,11 +39,13 @@ func (c Generator) String() string {
 	return fmt.Sprintf(`Generator Config
 - RawOutput           %t,
 - DisableTags         %t,
+- DisableReadingTime  %t,
 - SiteTitle           %s,
 - BlogRoot            %s,
 - Environment         %s`,
 		c.RawOutput,
 		c.DisableTags.Disable,
+		c.DisableReadingTime.Disable,
 		c.SiteTitle,
 		c.BlogRoot,
 		c.Environment.Environment,
@@ -73,6 +76,8 @@ func New(posts fs.FS, renderer *TemplateRenderer, opts ...config.GeneratorOption
 			opt.WithRawOutputFunc(&gen.RawOutput)
 		} else if opt.WithDisableTagsFunc != nil {
 			opt.WithDisableTagsFunc(&gen.DisableTags)
+		} else if opt.WithDisableReadingTimeFunc != nil {
+			opt.WithDisableReadingTimeFunc(&gen.DisableReadingTime)
 		} else if opt.WithSiteTitleFunc != nil {
 			opt.WithSiteTitleFunc(&gen.SiteTitle)
 		} else if opt.WithBlogRootFunc != nil {
@@ -180,6 +185,13 @@ func (g *Generator) assembleBlogWithTemplates(ctx context.Context, posts models.
 	if !tagsEnabled {
 		for _, post := range posts {
 			post.Tags = nil
+		}
+	}
+
+	// Compute reading time for each post unless disabled.
+	if !g.DisableReadingTime.Disable {
+		for _, post := range posts {
+			post.ReadingTimeMinutes = minutesFromWords(wordCount(post.Content))
 		}
 	}
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -57,9 +57,9 @@ func (c Generator) String() string {
 // resources cannot be initialized.
 //
 // Optional config.GeneratorOption values control behavior: config.WithRawOutput,
-// config.WithDisableTags, config.WithSiteTitle, config.WithBlogRoot,
-// config.WithEnvironment. The template renderer is supplied as a positional
-// argument, not an option.
+// config.WithDisableTags, config.WithDisableReadingTime, config.WithSiteTitle,
+// config.WithBlogRoot, config.WithEnvironment. The template renderer is supplied
+// as a positional argument, not an option.
 func New(posts fs.FS, renderer *TemplateRenderer, opts ...config.GeneratorOption) *Generator {
 	logger := slog.Default()
 

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -1096,6 +1096,75 @@ func TestGenerate_TagsEnabledInTemplateData(t *testing.T) {
 	}
 }
 
+// TestWithDisableReadingTime tests that the WithDisableReadingTime option is applied correctly.
+func TestWithDisableReadingTime(t *testing.T) {
+	t.Parallel()
+
+	testFS := os.DirFS("testdata")
+
+	genDefault := New(testFS, nil)
+	if genDefault.DisableReadingTime.Disable {
+		t.Error("Generator without WithDisableReadingTime() should have Disable = false")
+	}
+
+	genDisabled := New(testFS, nil, config.WithDisableReadingTime())
+	if !genDisabled.DisableReadingTime.Disable {
+		t.Error("Generator with WithDisableReadingTime() should have Disable = true")
+	}
+}
+
+// TestGenerate_ReadingTimePopulated verifies that generated posts have ReadingTimeMinutes >= 1
+// by default and that it is zero when WithDisableReadingTime() is supplied.
+func TestGenerate_ReadingTimePopulated(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	postContent := `---
+title: Reading Time Post
+date: 2024-05-01
+description: Testing reading time
+tags: [test]
+---
+# Reading Time Post
+
+` + strings.Repeat("word ", 300) + `
+`
+	if err := os.WriteFile(tempDir+"/rt.md", []byte(postContent), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	renderer, err := NewTemplateRenderer(os.DirFS("../templates/default"))
+	if err != nil {
+		t.Fatalf("NewTemplateRenderer() error = %v", err)
+	}
+
+	testFS := os.DirFS(tempDir)
+
+	// Enabled (default): ReadingTimeMinutes should be >= 1.
+	gen := New(testFS, renderer, config.WithSiteTitle("Test"))
+	blog, err := gen.Generate(context.Background())
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	for slug, content := range blog.Posts {
+		if !contains(string(content), "min read") {
+			t.Errorf("post %q: expected 'min read' in output when reading time is enabled", slug)
+		}
+	}
+
+	// Disabled: ReadingTimeMinutes should be zero, 'min read' absent.
+	genDisabled := New(testFS, renderer, config.WithSiteTitle("Test"), config.WithDisableReadingTime())
+	blogDisabled, err := genDisabled.Generate(context.Background())
+	if err != nil {
+		t.Fatalf("Generate() with DisableReadingTime error = %v", err)
+	}
+	for slug, content := range blogDisabled.Posts {
+		if contains(string(content), "min read") {
+			t.Errorf("post %q: unexpected 'min read' in output when reading time is disabled", slug)
+		}
+	}
+}
+
 // Helper function to check if a string contains a substring (case-insensitive).
 func contains(s, substr string) bool {
 	return bytes.Contains([]byte(strings.ToLower(s)), []byte(strings.ToLower(substr)))

--- a/pkg/generator/readingtime.go
+++ b/pkg/generator/readingtime.go
@@ -1,0 +1,31 @@
+package generator
+
+import (
+	"math"
+	"regexp"
+	"strings"
+)
+
+const wordsPerMinute = 220
+
+var tagRE = regexp.MustCompile(`<[^>]*>`)
+
+// wordCount strips HTML tags from rendered content and counts whitespace-separated tokens.
+// Tags are replaced with a space so adjacent elements don't merge their words.
+func wordCount(html []byte) int {
+	stripped := tagRE.ReplaceAll(html, []byte(" "))
+	return len(strings.Fields(string(stripped)))
+}
+
+// minutesFromWords converts a word count to an estimated reading time in minutes.
+// Uses a ceiling division at wordsPerMinute WPM with a 1-minute floor.
+func minutesFromWords(n int) int {
+	if n <= 0 {
+		return 1
+	}
+	m := int(math.Ceil(float64(n) / float64(wordsPerMinute)))
+	if m < 1 {
+		return 1
+	}
+	return m
+}

--- a/pkg/generator/readingtime_test.go
+++ b/pkg/generator/readingtime_test.go
@@ -1,0 +1,92 @@
+package generator
+
+import (
+	"testing"
+)
+
+func TestWordCount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{
+			name:  "plain prose",
+			input: "one two three",
+			want:  3,
+		},
+		{
+			name:  "HTML tags stripped",
+			input: "<p>hello <em>world</em></p>",
+			want:  2,
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  0,
+		},
+		{
+			name:  "adjacent tags do not glue words",
+			input: "<p>a</p><p>b</p>",
+			want:  2,
+		},
+		{
+			name:  "code blocks counted",
+			input: "<pre><code>foo bar</code></pre>",
+			want:  2,
+		},
+		{
+			name:  "HTML entity inside word counted once",
+			input: "it&#39;s",
+			want:  1,
+		},
+		{
+			name:  "only whitespace",
+			input: "   \t\n  ",
+			want:  0,
+		},
+		{
+			name:  "mixed content",
+			input: "<h1>Title</h1><p>Some <strong>bold</strong> text.</p>",
+			want:  4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := wordCount([]byte(tt.input))
+			if got != tt.want {
+				t.Errorf("wordCount(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMinutesFromWords(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		words int
+		want  int
+	}{
+		{0, 1},
+		{1, 1},
+		{-1, 1},
+		{219, 1},
+		{220, 1},
+		{221, 2},
+		{440, 2},
+		{441, 3},
+		{1100, 5},
+	}
+
+	for _, tt := range tests {
+		got := minutesFromWords(tt.words)
+		if got != tt.want {
+			t.Errorf("minutesFromWords(%d) = %d, want %d", tt.words, got, tt.want)
+		}
+	}
+}

--- a/pkg/models/post.go
+++ b/pkg/models/post.go
@@ -18,13 +18,14 @@ type Post struct {
 	Tags        []string  `yaml:"tags"`
 
 	// Generated fields
-	Slug        string        // URL-friendly identifier
-	Content     []byte        // Rendered HTML content
-	HTMLContent template.HTML // HTML content for templates (not escaped)
-	RawContent  string        // Original markdown content
-	SourcePath  string        // Path to source markdown file
-	PublishDate time.Time     // Formatted publish date
-	BlogRoot    string        // Blog root path for URLs (e.g., "/" or "/blog/")
+	Slug               string        // URL-friendly identifier
+	Content            []byte        // Rendered HTML content
+	HTMLContent        template.HTML // HTML content for templates (not escaped)
+	RawContent         string        // Original markdown content
+	SourcePath         string        // Path to source markdown file
+	PublishDate        time.Time     // Formatted publish date
+	BlogRoot           string        // Blog root path for URLs (e.g., "/" or "/blog/")
+	ReadingTimeMinutes int           // Estimated reading time in minutes (0 = disabled)
 }
 
 // Validate checks if the post has all required fields.

--- a/pkg/templates/default/pages/post.tmpl
+++ b/pkg/templates/default/pages/post.tmpl
@@ -10,7 +10,7 @@
             <header class="mb-8">
                 <!-- Date -->
                 <time datetime="{{.Post.Date.Format "2006-01-02"}}" class="text-sm text-gray-500">
-                    {{.Post.FormattedDate}}
+                    {{.Post.FormattedDate}}{{if .Post.ReadingTimeMinutes}} · {{.Post.ReadingTimeMinutes}} min read{{end}}
                 </time>
 
                 <!-- Title -->


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
### Changelog ([#39](https://github.com/harrydayexe/GoBlog/pull/39))

#### ✨ New Features
- add reading time estimation to blog posts (#38)

#### 📚 Documentation
- add reading time documentation to godoc and README

#### 🧹 Chores
- add CLAUDE.md with documentation requirement

<!--- END AUTOGENERATED NOTES --->