### PR TITLE
Add Docker image CI job and local build recipe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,24 @@ jobs:
 
       - name: Run tests with race detector
         run: go test -race ./...
+
+  build-docker-image:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          tags: goblog:latest
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build and push Docker image
+      - name: Build Docker image
         uses: docker/build-push-action@v7
         with:
           context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /build
 

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ LDFLAGS := '-s -w -X main.version=' + VERSION + ' -X main.commit=' + COMMIT + ' 
 
 # Build binary for current OS/architecture
 [default]
-[group("dev")]
+[group("build")]
 build:
     @echo "Building {{BINARY_NAME}}..."
     @mkdir -p {{DIST_DIR}}
@@ -118,3 +118,10 @@ run-serve *ARGS:
     else
         go run {{MAIN_PATH}} serve {{ARGS}}
     fi
+
+# Build the dockerfile for the current architecture
+[group("build")]
+docker tag="goblog:latest":
+    @echo "Building Docker image..."
+    docker build -t {{tag}} .
+    @echo "✓ Docker image built successfully"


### PR DESCRIPTION
- Update Dockerfile base image to golang:1.26-alpine (matches go 1.26 toolchain)
- Add build-docker-image job to test.yml that builds for amd64 and arm64 without pushing
- Add `docker` recipe to justfile for local image builds, grouped under "build"
- Move the `build` recipe from group "dev" to group "build" for consistency
<!--- START AUTOGENERATED NOTES --->
### Changelog ([#42](https://github.com/harrydayexe/GoBlog/pull/42))

#### 🏗️ Build System
- add Docker image CI job and local build recipe

#### 🤖 CI
- rename build docker image job

<!--- END AUTOGENERATED NOTES --->