### PR TITLE
feat(models): add optional author field to post front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ title: "My Blog Post Title"
 date: 2024-01-15
 description: "A brief description of the post"
 tags: ["go", "blogging", "markdown"]
+author: "Jane Doe"
 ---
 
 # Post Content
@@ -112,6 +113,8 @@ func main() {
 }
 \`\`\`
 ```
+
+The `author` field is optional. When omitted, `Post.Author` is an empty string and no error is returned. Access it in a custom post template via `{{.Post.Author}}`.
 
 ## CLI Usage
 

--- a/pkg/models/post.go
+++ b/pkg/models/post.go
@@ -16,6 +16,9 @@ type Post struct {
 	Date        time.Time `yaml:"date"`
 	Description string    `yaml:"description"`
 	Tags        []string  `yaml:"tags"`
+	// Author is the name of the post's author. It is optional; when not declared
+	// in the front matter it defaults to an empty string.
+	Author string `yaml:"author"`
 
 	// Generated fields
 	Slug               string        // URL-friendly identifier

--- a/pkg/models/post_test.go
+++ b/pkg/models/post_test.go
@@ -59,6 +59,16 @@ func TestPost_Validate(t *testing.T) {
 			expectErr: true,
 			errText:   "description",
 		},
+		{
+			name: "empty author is valid",
+			post: Post{
+				Title:       "Test Post",
+				Date:        now,
+				Description: "A test post",
+				Author:      "",
+			},
+			expectErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/parser/examples_test.go
+++ b/pkg/parser/examples_test.go
@@ -84,7 +84,7 @@ func ExampleParser_ParseDirectory() {
 
 	fmt.Printf("Valid posts: %d\n", len(posts))
 	// Output: Parsed with some errors
-	// Valid posts: 3
+	// Valid posts: 4
 	// Errors: 4
 }
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -35,6 +35,10 @@ func TestParseFile_ValidPost(t *testing.T) {
 		t.Error("expected valid date, got zero time")
 	}
 
+	if post.Author != "Jane Doe" {
+		t.Errorf("expected author 'Jane Doe', got: %s", post.Author)
+	}
+
 	// Check generated fields
 	if post.SourcePath != "valid-post.md" {
 		t.Errorf("expected source path 'valid-post.md', got: %s", post.SourcePath)
@@ -64,6 +68,21 @@ func TestParseFile_ValidPost(t *testing.T) {
 	// Verify markdown was converted (should contain <strong> for **)
 	if !strings.Contains(string(post.Content), "<strong>valid</strong>") {
 		t.Error("expected rendered HTML to contain bold text")
+	}
+}
+
+func TestParseFile_NoAuthor(t *testing.T) {
+	t.Parallel()
+	p := New()
+	fsys := os.DirFS("testdata")
+
+	post, err := p.ParseFile(context.Background(), fsys, "no-author.md")
+	if err != nil {
+		t.Fatalf("expected no error for post without author, got: %v", err)
+	}
+
+	if post.Author != "" {
+		t.Errorf("expected empty author, got: %s", post.Author)
 	}
 }
 

--- a/pkg/parser/testdata/no-author.md
+++ b/pkg/parser/testdata/no-author.md
@@ -1,0 +1,10 @@
+---
+title: "A Post Without an Author"
+date: 2026-01-11T10:00:00Z
+description: "This post has no author field in its front matter"
+tags: [go, testing]
+---
+
+# No Author
+
+This is a valid post that omits the optional author field.

--- a/pkg/parser/testdata/valid-post.md
+++ b/pkg/parser/testdata/valid-post.md
@@ -3,6 +3,7 @@ title: "A Valid Blog Post"
 date: 2026-01-10T10:00:00Z
 description: "This is a test post with all required fields"
 tags: [go, testing, blog]
+author: "Jane Doe"
 ---
 
 # Welcome to My Blog


### PR DESCRIPTION
Parses an `author` key from each post's YAML front matter and exposes it as Post.Author. The field is optional — when omitted it defaults to an empty string and Validate() does not flag it as an error.

Closes #44
<!--- START AUTOGENERATED NOTES --->
### Changelog ([#46](https://github.com/harrydayexe/GoBlog/pull/46))

#### ✨ New Features
- (models) add optional author field to post front matter

<!--- END AUTOGENERATED NOTES --->