### PR TITLE
fix: remove broken version resolvers

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,8 +25,6 @@ builds:
     ldflags:
       - -s -w
       - -X main.version={{.Version}}
-      - -X main.commit={{.Commit}}
-      - -X main.date={{.Date}}
 
 archives:
   - id: goblog

--- a/cmd/goblog/main.go
+++ b/cmd/goblog/main.go
@@ -17,12 +17,8 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-// These are replaced at build time by GoReleaser
-var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
-)
+// version is replaced at build time by GoReleaser
+var version = "dev"
 
 func main() {
 	var verbosity int
@@ -35,11 +31,10 @@ func main() {
 	}
 
 	cli.VersionPrinter = func(cmd *cli.Command) {
-		v, c, d := buildVersion()
-		fmt.Printf("GoBlog version %s\nCommit %s\nDate %s\n", v, c, d)
+		fmt.Printf("GoBlog version %s\n", buildVersion())
 	}
 
-	v, _, _ := buildVersion()
+	v := buildVersion()
 	cmd := &cli.Command{
 		Name:                   "GoBlog",
 		Usage:                  "Create a blog feed from posts written in Markdown!",

--- a/cmd/goblog/version.go
+++ b/cmd/goblog/version.go
@@ -4,62 +4,26 @@
 
 package main
 
-import (
-	"regexp"
-	"runtime/debug"
-)
+import "runtime/debug"
 
-// pseudoVersionRe matches Go pseudo-versions: v0.0.0-YYYYMMDDhhmmss-abcdefabcdef
-var pseudoVersionRe = regexp.MustCompile(`-(\d{14})-([0-9a-f]{12})$`)
-
-// buildVersion returns the version, commit, and date for the running binary.
-// When GoReleaser ldflags are present they are returned as-is. Otherwise the
-// values are derived from the embedded Go module and VCS build metadata, so
-// binaries installed via go install report useful information rather than the
-// placeholder defaults. It is safe to call from multiple goroutines.
-func buildVersion() (ver, com, dat string) {
-	// Ldflag path: GoReleaser has already injected real values.
+// buildVersion returns the version string for the running binary.
+// When GoReleaser ldflags are present the injected value is returned as-is.
+// Otherwise the value is derived from the embedded Go module build metadata,
+// so binaries installed via go install report the module tag. It is safe to
+// call from multiple goroutines.
+func buildVersion() string {
 	if version != "dev" {
-		return version, commit, date
+		return version
 	}
-
-	ver, com, dat = version, commit, date
 
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
-		return
+		return version
 	}
 
 	if v := info.Main.Version; v != "" && v != "(devel)" {
-		ver = v
+		return v
 	}
 
-	for _, s := range info.Settings {
-		switch s.Key {
-		case "vcs.revision":
-			if len(s.Value) >= 7 {
-				com = s.Value[:7]
-			} else {
-				com = s.Value
-			}
-		case "vcs.time":
-			dat = s.Value
-		case "vcs.modified":
-			if s.Value == "true" && com != "none" {
-				com += "+dirty"
-			}
-		}
-	}
-
-	// For go install builds, vcs.* settings are not populated but the version
-	// is a pseudo-version that encodes the date and commit SHA.
-	if com == "none" && dat == "unknown" {
-		if m := pseudoVersionRe.FindStringSubmatch(ver); m != nil {
-			raw := m[1] // YYYYMMDDhhmmss
-			dat = raw[:4] + "-" + raw[4:6] + "-" + raw[6:8] + "T" + raw[8:10] + ":" + raw[10:12] + ":" + raw[12:14] + "Z"
-			com = m[2][:7]
-		}
-	}
-
-	return
+	return version
 }

--- a/justfile
+++ b/justfile
@@ -8,11 +8,9 @@ MAIN_PATH := "./cmd/goblog"
 DIST_DIR := "dist"
 COVERAGE_DIR := "coverage"
 
-# Build-time version injection using git commands
+# Build-time version injection using git tags
 VERSION := `git describe --tags --always --dirty 2>/dev/null || echo "dev"`
-COMMIT := `git rev-parse --short HEAD 2>/dev/null || echo "none"`
-DATE := `date -u +%Y-%m-%dT%H:%M:%SZ`
-LDFLAGS := '-s -w -X main.version=' + VERSION + ' -X main.commit=' + COMMIT + ' -X main.date=' + DATE
+LDFLAGS := '-s -w -X main.version=' + VERSION
 
 # Build binary for current OS/architecture
 [default]


### PR DESCRIPTION
Fixes #33
<!--- START AUTOGENERATED NOTES --->
### Changelog ([#50](https://github.com/harrydayexe/GoBlog/pull/50))

#### 🐛 Bug Fixes
- remove broken version resolvers

<!--- END AUTOGENERATED NOTES --->