### PR TITLE
feat(watcher): add file watching for new and updates posts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,3 +8,7 @@ The README.md does not need to be flooded with documentation. Just the relevant 
 1. CLI tool via go install
 2. Docker image via docker pull/run
 3. The library itself
+
+## Config Pattern
+
+All configurable values are defined as named types in `pkg/config` (e.g. `type Port int`, `type WatcherDebounce struct{ Debounce time.Duration }`). These types are **embedded directly** into the structs that consume them (`Server`, `Generator`, `Watcher`), not stored as plain unexported fields. Option constructor functions (e.g. `WithPort`, `WithLogger`) live in `pkg/config` and return an option struct with exactly one non-nil function pointer. Options are applied in an `else if` chain passing a pointer to the embedded field: `if opt.WithXFunc != nil { opt.WithXFunc(&s.X) } else if opt.WithYFunc != nil { ... }`. New configurable behaviour always follows this pattern end-to-end: config type in `pkg/config`, option function in `pkg/config`, embedded field in the consumer struct.

--- a/README.md
+++ b/README.md
@@ -44,15 +44,22 @@ goblog serve posts/
 | `--disable-reading-time` | | `false` | Disable reading time estimation on posts |
 | `--root-path` | `-p` | `/` | Blog root path for subdirectory deployment |
 | `--template-dir` | `-t` | built-in | Path to a custom template directory |
+| `--watch` | `-w` | `false` | Watch the posts directory and regenerate on changes |
 
 ## Docker
 
-The official image is [`harrydayexe/goblog`](https://hub.docker.com/repository/docker/harrydayexe/goblog/general). It runs `goblog serve /posts` by default and exposes port `8080`.
+The official image is [`harrydayexe/goblog`](https://hub.docker.com/repository/docker/harrydayexe/goblog/general). It runs `goblog serve /posts` by default and exposes port `8080`. File watching is off by default; pass `--watch` to enable it.
 
 Mount your Markdown posts directory to `/posts`:
 
 ```bash
 docker run -v ./posts:/posts -p 8080:8080 harrydayexe/goblog
+```
+
+To watch for post changes and reload automatically:
+
+```bash
+docker run -v ./posts:/posts -p 8080:8080 harrydayexe/goblog /posts --watch
 ```
 
 Pass any `serve` flags after the image name — re-supply the posts path as the first argument:

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/caarlos0/env/v11 v11.3.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
+	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	golang.org/x/sys v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZ
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/harrydayexe/GoWebUtilities v1.4.0 h1:0eu46pc0NbJFTyZJTrxDR+CmBUD6yiGbkVbN8sn8+1U=
 github.com/harrydayexe/GoWebUtilities v1.4.0/go.mod h1:msGwhqkUbSAhhIR+uFnLE08OhBCwuJW0BQ5kUnBvI6I=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=

--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -55,5 +55,11 @@ var ServeCommand cli.Command = cli.Command{
 			Usage: "disable reading time estimation on posts",
 			Value: false,
 		},
+		&cli.BoolFlag{
+			Name:    WatchFlagName,
+			Aliases: []string{"w"},
+			Usage:   "watch the posts directory and regenerate the blog on changes",
+			Value:   false,
+		},
 	},
 }

--- a/internal/server/command_test.go
+++ b/internal/server/command_test.go
@@ -10,12 +10,16 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/harrydayexe/GoBlog/v2/pkg/config"
 	pkgserver "github.com/harrydayexe/GoBlog/v2/pkg/server"
+	"github.com/harrydayexe/GoBlog/v2/pkg/watcher"
 )
 
 var testPost = strings.TrimSpace(`
@@ -52,7 +56,7 @@ func TestRunServe_CanceledContext(t *testing.T) {
 		Server: []config.BaseServerOption{config.WithPort(0)},
 	}
 
-	err := runServe(ctx, discardLogger(), testFS(), cfg)
+	err := runServe(ctx, discardLogger(), t.TempDir(), testFS(), cfg, false)
 	if err != nil {
 		t.Errorf("runServe() with canceled context error = %v, want nil", err)
 	}
@@ -134,4 +138,86 @@ func TestRunServe_BlogRoot(t *testing.T) {
 	if rec2.Code != http.StatusNotFound {
 		t.Errorf("GET / with blog root status = %d, want %d", rec2.Code, http.StatusNotFound)
 	}
+}
+
+// TestRunServe_WatchBadPath verifies that runServe fails fast when --watch is
+// enabled but the posts path does not exist.
+func TestRunServe_WatchBadPath(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cfg := config.ServerConfig{
+		Server: []config.BaseServerOption{config.WithPort(0)},
+	}
+
+	err := runServe(ctx, discardLogger(), "/nonexistent/goblog/watch/test", testFS(), cfg, true)
+	if err == nil {
+		t.Error("runServe() with watch=true and bad path returned nil, want error")
+	}
+}
+
+// TestRunServe_WatchReloadsPost verifies that writing a new post file to a
+// watched directory causes it to be served by the server. It wires
+// pkg/watcher and pkg/server together directly, mirroring the integration
+// that runServe performs.
+func TestRunServe_WatchReloadsPost(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "test-post.md"), []byte(testPost), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	cfg := config.ServerConfig{
+		Server: []config.BaseServerOption{config.WithPort(0)},
+	}
+
+	srv, err := pkgserver.New(discardLogger(), os.DirFS(dir), cfg)
+	if err != nil {
+		t.Fatalf("server.New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	w, err := watcher.New(dir, config.WithDebounce(50*time.Millisecond))
+	if err != nil {
+		t.Fatalf("watcher.New() error = %v", err)
+	}
+	go w.Run(ctx, func(ctx context.Context) { //nolint:errcheck
+		if err := srv.UpdatePosts(os.DirFS(dir), ctx); err != nil {
+			t.Logf("UpdatePosts error: %v", err)
+		}
+	})
+
+	// Give the watcher time to start.
+	time.Sleep(100 * time.Millisecond)
+
+	newPost := strings.TrimSpace(`
+---
+title: New Post
+description: A new post
+date: 2024-06-01
+tags: [new]
+---
+
+# New Post
+
+This is a new post.
+`)
+	if err := os.WriteFile(filepath.Join(dir, "new-post.md"), []byte(newPost), 0o644); err != nil {
+		t.Fatalf("WriteFile new-post error = %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/posts/new-post", nil))
+		if rec.Code == http.StatusOK {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Error("new post not available after 5s of watching")
 }

--- a/internal/server/flagConsts.go
+++ b/internal/server/flagConsts.go
@@ -24,3 +24,6 @@ const DisableTagsFlagName = "disable-tags"
 
 // DisableReadingTimeFlagName is the CLI flag name for disabling reading time estimation.
 const DisableReadingTimeFlagName = "disable-reading-time"
+
+// WatchFlagName is the CLI flag name for enabling filesystem watching.
+const WatchFlagName = "watch"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/harrydayexe/GoBlog/v2/pkg/config"
 	"github.com/harrydayexe/GoBlog/v2/pkg/server"
 	"github.com/harrydayexe/GoBlog/v2/pkg/templates"
+	"github.com/harrydayexe/GoBlog/v2/pkg/watcher"
 	gwucfg "github.com/harrydayexe/GoWebUtilities/config"
 	"github.com/urfave/cli/v3"
 )
@@ -78,13 +79,30 @@ func NewServeCommand(ctx context.Context, c *cli.Command) error {
 		cfg.Gen = append(cfg.Gen, config.WithBaseOption(config.WithBlogRoot(blogRoot)))
 	}
 
-	return runServe(ctx, slog.Default(), postsFsys, cfg)
+	return runServe(ctx, slog.Default(), inputPostsDir, postsFsys, cfg, c.Bool(WatchFlagName))
 }
 
-func runServe(ctx context.Context, logger *slog.Logger, posts fs.FS, cfg config.ServerConfig) error {
+func runServe(ctx context.Context, logger *slog.Logger, postsPath string, posts fs.FS, cfg config.ServerConfig, watch bool) error {
 	srv, err := server.New(logger, posts, cfg)
 	if err != nil {
 		return err
 	}
+
+	if watch {
+		w, err := watcher.New(postsPath)
+		if err != nil {
+			return err
+		}
+		go func() {
+			if err := w.Run(ctx, func(ctx context.Context) {
+				if err := srv.UpdatePosts(os.DirFS(postsPath), ctx); err != nil {
+					logger.WarnContext(ctx, "watcher: failed to reload posts", slog.Any("error", err))
+				}
+			}); err != nil {
+				logger.WarnContext(ctx, "watcher: stopped with error", slog.Any("error", err))
+			}
+		}()
+	}
+
 	return srv.Run(ctx)
 }

--- a/justfile
+++ b/justfile
@@ -91,6 +91,11 @@ vet:
 fmt:
     go fmt ./...
 
+# Run vulncheck on codebase
+[group("lint")]
+vulncheck:
+    govulncheck ./...
+
 # Check if code is formatted
 [group("lint")]
 fmt-check:

--- a/pkg/config/watcherOption.go
+++ b/pkg/config/watcherOption.go
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package config
+
+import "time"
+
+// WatcherOption represents a configuration option for a filesystem Watcher.
+// Options use the functional options pattern; each value carries a function
+// pointer that modifies a specific watcher setting.
+//
+// This type should not be constructed directly. Use the provided option
+// functions: WithDebounce.
+type WatcherOption struct {
+	WithDebounceFunc func(v *WatcherDebounce)
+}
+
+// WatcherDebounce holds the event debounce duration for the watcher.
+// Events that arrive within this window are coalesced into a single callback
+// invocation.
+type WatcherDebounce struct{ Debounce time.Duration }
+
+// WithDebounce returns a WatcherOption that sets the event debounce window.
+// File-system events that arrive within this duration of each other are
+// coalesced into a single onChange invocation. Defaults to 300ms.
+//
+// Example usage:
+//
+//	w, err := watcher.New("posts/", config.WithDebounce(500*time.Millisecond))
+func WithDebounce(d time.Duration) WatcherOption {
+	return WatcherOption{
+		WithDebounceFunc: func(v *WatcherDebounce) { v.Debounce = d },
+	}
+}

--- a/pkg/server/doc.go
+++ b/pkg/server/doc.go
@@ -118,6 +118,19 @@
 // The handler swap is atomic - in-flight requests complete with the old handler
 // while new requests immediately see the updated content.
 //
+// For automatic filesystem-triggered reloads, use pkg/watcher alongside
+// UpdatePosts. The watcher watches a directory tree for changes and invokes
+// a callback (debounced) on each change:
+//
+//	postsPath := "posts/"
+//	w, err := watcher.New(postsPath, watcher.WithLogger(logger))
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	go w.Run(ctx, func(ctx context.Context) {
+//	    srv.UpdatePosts(os.DirFS(postsPath), ctx)
+//	})
+//
 // # Concurrency
 //
 // All Server methods are safe for concurrent use by multiple goroutines.

--- a/pkg/watcher/doc.go
+++ b/pkg/watcher/doc.go
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Package watcher provides recursive filesystem watching with debouncing for
+// blog post directories.
+//
+// It wraps github.com/fsnotify/fsnotify with automatic recursive directory
+// watching (fsnotify only watches individual directories non-recursively) and
+// a configurable debounce window that coalesces rapid bursts of events — such
+// as those produced by editors that write files in multiple steps — into a
+// single callback invocation.
+//
+// # Basic Usage
+//
+// Create a Watcher rooted at a posts directory and run it alongside a
+// pkg/server.Server to achieve live content reload:
+//
+//	import (
+//	    "context"
+//	    "log/slog"
+//	    "os"
+//
+//	    "github.com/harrydayexe/GoBlog/v2/pkg/server"
+//	    "github.com/harrydayexe/GoBlog/v2/pkg/watcher"
+//	)
+//
+//	postsPath := "posts/"
+//
+//	w, err := watcher.New(postsPath)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	ctx, cancel := context.WithCancel(context.Background())
+//	defer cancel()
+//
+//	// srv is a *server.Server created with server.New(...)
+//	go w.Run(ctx, func(ctx context.Context) {
+//	    if err := srv.UpdatePosts(os.DirFS(postsPath), ctx); err != nil {
+//	        slog.Warn("failed to reload posts", "error", err)
+//	    }
+//	})
+//
+//	// srv.Run blocks until the server shuts down.
+//	if err := srv.Run(ctx); err != nil {
+//	    log.Fatal(err)
+//	}
+//
+// # Setup Errors
+//
+// New fails hard on any problem detected at setup time: root path missing or
+// not a directory, fsnotify initialisation failure, or any individual
+// directory failing to be added to the watch list (e.g. due to exceeding the
+// Linux inotify watch limit). These are surfaced immediately so the user is
+// aware that watching is not working as requested.
+//
+// # Runtime Behaviour
+//
+// Once Run is active, errors are logged at warn level and the loop continues.
+// This includes fsnotify errors and failures adding newly created
+// subdirectories to the watch set.
+//
+// Subdirectories created after the Watcher is constructed are automatically
+// picked up by Run when the parent directory fires a Create event.
+//
+// Only changes to files with a .md extension trigger the onChange callback.
+// All other file types (images, CSS, YAML, etc.) are silently ignored, as
+// are common editor temporary files (dotfiles, *.swp, *~, etc.).
+// Deletion of already-watched directories is not currently handled:
+// the watcher stops receiving events for deleted directory trees but does not
+// error. See the project issue tracker for a planned improvement.
+//
+// # Concurrency
+//
+// New and Run are not safe for concurrent use on the same Watcher. Typically
+// a single Watcher is created once and Run in a dedicated goroutine.
+package watcher

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -1,0 +1,173 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/harrydayexe/GoBlog/v2/pkg/config"
+)
+
+// Watcher watches a directory tree for filesystem changes and invokes a
+// callback, debounced, whenever changes are detected.
+type Watcher struct {
+	path string
+
+	config.WatcherDebounce
+
+	fw *fsnotify.Watcher
+}
+
+// New creates a Watcher rooted at path. It recursively watches path and all
+// subdirectories that exist at creation time. Subdirectories created after
+// New returns are picked up automatically inside Run when their parent fires
+// a Create event.
+//
+// New fails immediately if any part of setup fails — including the root path
+// being missing, fsnotify initialisation failing, or any subdirectory failing
+// to be added to the watch list. Callers should not attempt to fall back
+// silently; surface the error to the user.
+//
+// Call Run to begin receiving events.
+func New(path string, opts ...config.WatcherOption) (*Watcher, error) {
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("watcher: failed to create fsnotify watcher: %w", err)
+	}
+
+	w := &Watcher{
+		path:            path,
+		WatcherDebounce: config.WatcherDebounce{Debounce: 300 * time.Millisecond},
+		fw:              fw,
+	}
+
+	for _, opt := range opts {
+		if opt.WithDebounceFunc != nil {
+			opt.WithDebounceFunc(&w.WatcherDebounce)
+		}
+	}
+
+	if err := w.addDirs(path); err != nil {
+		fw.Close()
+		return nil, err
+	}
+
+	return w, nil
+}
+
+// Run blocks, watching for filesystem events, until ctx is canceled.
+// onChange is invoked (with a child context) whenever file changes are
+// detected, coalesced over the configured debounce window. Multiple events
+// within the window trigger only one onChange call.
+//
+// Errors from the fsnotify event stream are logged at warn level but do not
+// stop the watch loop. Run returns nil when ctx is canceled.
+func (w *Watcher) Run(ctx context.Context, onChange func(context.Context)) error {
+	defer w.fw.Close()
+
+	logger := slog.Default()
+
+	timer := time.NewTimer(0)
+	<-timer.C // drain so it doesn't fire immediately
+
+	for {
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil
+
+		case event, ok := <-w.fw.Events:
+			if !ok {
+				return nil
+			}
+			if isNoise(event.Name) {
+				continue
+			}
+			logger.DebugContext(ctx, "file event", slog.String("path", event.Name), slog.String("op", event.Op.String()))
+
+			// If a new directory appeared, watch it — then skip the
+			// debounce reset since a bare directory create is not a
+			// content change.
+			if event.Has(fsnotify.Create) {
+				if fi, err := os.Stat(event.Name); err == nil && fi.IsDir() {
+					if err := w.fw.Add(event.Name); err != nil {
+						logger.WarnContext(ctx, "watcher: failed to add new directory", slog.String("path", event.Name), slog.Any("error", err))
+					} else {
+						logger.DebugContext(ctx, "watcher: watching new directory", slog.String("path", event.Name))
+					}
+					continue
+				}
+			}
+
+			// Only regenerate for markdown file changes.
+			if filepath.Ext(event.Name) != ".md" {
+				continue
+			}
+
+			// Reset debounce timer.
+			timer.Stop()
+			timer.Reset(w.Debounce)
+
+		case err, ok := <-w.fw.Errors:
+			if !ok {
+				return nil
+			}
+			logger.WarnContext(ctx, "watcher: fsnotify error", slog.Any("error", err))
+
+		case <-timer.C:
+			logger.InfoContext(ctx, "watcher: posts changed, regenerating")
+			childCtx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			onChange(childCtx)
+		}
+	}
+}
+
+// addDirs walks path and adds every directory (including path itself) to the
+// fsnotify watcher. Returns an error if path is not a directory or if any
+// Add call fails.
+func (w *Watcher) addDirs(path string) error {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("watcher: cannot stat path %q: %w", path, err)
+	}
+	if !fi.IsDir() {
+		return fmt.Errorf("watcher: path %q is not a directory", path)
+	}
+
+	return filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("watcher: error walking %q: %w", p, err)
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if err := w.fw.Add(p); err != nil {
+			return fmt.Errorf("watcher: failed to watch directory %q: %w", p, err)
+		}
+		slog.Default().Debug("watcher: watching directory", slog.String("path", p))
+		return nil
+	})
+}
+
+// isNoise reports whether a filesystem event path should be ignored.
+// Matches common editor temporary files and OS metadata files.
+func isNoise(name string) bool {
+	base := filepath.Base(name)
+	if strings.HasPrefix(base, ".") {
+		return true
+	}
+	return strings.HasSuffix(base, ".swp") ||
+		strings.HasSuffix(base, ".swx") ||
+		strings.HasSuffix(base, "~")
+}

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -1,0 +1,239 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package watcher_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/harrydayexe/GoBlog/v2/pkg/config"
+	"github.com/harrydayexe/GoBlog/v2/pkg/watcher"
+)
+
+const shortDebounce = 50 * time.Millisecond
+
+// waitForCount blocks until count reaches target or the deadline passes.
+func waitForCount(t *testing.T, count *atomic.Int64, target int64, deadline time.Duration) {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if count.Load() >= target {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Errorf("onChange called %d time(s), want at least %d", count.Load(), target)
+}
+
+// TestNew_MissingPath verifies that New fails when the path does not exist.
+func TestNew_MissingPath(t *testing.T) {
+	t.Parallel()
+	_, err := watcher.New("/nonexistent/path/for/goblog/watcher/test")
+	if err == nil {
+		t.Error("New() with missing path returned nil error, want error")
+	}
+}
+
+// TestNew_FilePath verifies that New fails when path is a file, not a directory.
+func TestNew_FilePath(t *testing.T) {
+	t.Parallel()
+	f, err := os.CreateTemp(t.TempDir(), "not-a-dir-*.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	_, err = watcher.New(f.Name())
+	if err == nil {
+		t.Error("New() with file path returned nil error, want error")
+	}
+}
+
+// TestRun_Cancellation verifies that Run returns promptly when ctx is canceled.
+func TestRun_Cancellation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	w, err := watcher.New(dir, config.WithDebounce(shortDebounce))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx, func(context.Context) {}) }()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("Run() did not return within 2s after ctx cancellation")
+	}
+}
+
+// TestRun_FileChange verifies that onChange is called when a file is written.
+func TestRun_FileChange(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	w, err := watcher.New(dir, config.WithDebounce(shortDebounce))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	var count atomic.Int64
+	go w.Run(ctx, func(context.Context) { count.Add(1) }) //nolint:errcheck
+
+	// Give the watcher time to start listening before writing.
+	time.Sleep(50 * time.Millisecond)
+
+	if err := os.WriteFile(filepath.Join(dir, "post.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	waitForCount(t, &count, 1, 3*time.Second)
+}
+
+// TestRun_Debounce verifies that rapid writes coalesce into a single onChange call.
+func TestRun_Debounce(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	w, err := watcher.New(dir, config.WithDebounce(200*time.Millisecond))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	var count atomic.Int64
+	go w.Run(ctx, func(context.Context) { count.Add(1) }) //nolint:errcheck
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Write three files in quick succession.
+	for i := range 3 {
+		path := filepath.Join(dir, "post.md")
+		_ = i
+		if err := os.WriteFile(path, []byte("hello"), 0o644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Wait for debounce to settle.
+	time.Sleep(400 * time.Millisecond)
+
+	if got := count.Load(); got != 1 {
+		t.Errorf("onChange called %d time(s), want 1 (debounced)", got)
+	}
+}
+
+// TestRun_NewSubdirTracked verifies that files written inside a newly created
+// subdirectory also trigger onChange.
+func TestRun_NewSubdirTracked(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	w, err := watcher.New(dir, config.WithDebounce(shortDebounce))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	var count atomic.Int64
+	go w.Run(ctx, func(context.Context) { count.Add(1) }) //nolint:errcheck
+
+	time.Sleep(50 * time.Millisecond)
+
+	sub := filepath.Join(dir, "subdir")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatalf("Mkdir error = %v", err)
+	}
+	// Allow the watcher to pick up the new directory.
+	time.Sleep(100 * time.Millisecond)
+
+	if err := os.WriteFile(filepath.Join(sub, "post.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	waitForCount(t, &count, 1, 3*time.Second)
+}
+
+// TestRun_NonMarkdownIgnored verifies that changes to non-.md files do not trigger onChange.
+func TestRun_NonMarkdownIgnored(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	w, err := watcher.New(dir, config.WithDebounce(shortDebounce))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	var count atomic.Int64
+	go w.Run(ctx, func(context.Context) { count.Add(1) }) //nolint:errcheck
+
+	time.Sleep(50 * time.Millisecond)
+
+	nonMarkdown := []string{"post.html", "style.css", "config.yaml", "image.png"}
+	for _, name := range nonMarkdown {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("content"), 0o644); err != nil {
+			t.Fatalf("WriteFile %q error = %v", name, err)
+		}
+	}
+
+	time.Sleep(shortDebounce + 200*time.Millisecond)
+
+	if got := count.Load(); got != 0 {
+		t.Errorf("onChange called %d time(s) for non-markdown files, want 0", got)
+	}
+}
+
+// TestRun_NoiseIgnored verifies that dot-files and editor swap files are ignored.
+func TestRun_NoiseIgnored(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	w, err := watcher.New(dir, config.WithDebounce(shortDebounce))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	var count atomic.Int64
+	go w.Run(ctx, func(context.Context) { count.Add(1) }) //nolint:errcheck
+
+	time.Sleep(50 * time.Millisecond)
+
+	noiseFiles := []string{".DS_Store", ".hidden", "post.md.swp", "post.md~", "post.md.swx"}
+	for _, name := range noiseFiles {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("ignored"), 0o644); err != nil {
+			t.Fatalf("WriteFile %q error = %v", name, err)
+		}
+	}
+
+	// Wait longer than the debounce to confirm no callback fires.
+	time.Sleep(shortDebounce + 200*time.Millisecond)
+
+	if got := count.Load(); got != 0 {
+		t.Errorf("onChange called %d time(s) for noise files, want 0", got)
+	}
+}


### PR DESCRIPTION
Adds a new `pkg/watcher` package (backed by fsnotify) that recursively
watches a posts directory for .md file changes and debounces events into
a single regeneration callback. Wiring it to `srv.UpdatePosts` gives the
server atomic live reload without a restart.

The `--watch` / `-w` flag on `goblog serve` is off by default everywhere
(including the Docker image). Setup errors fail fast; runtime errors from
the fsnotify loop are logged at warn level and the loop continues.

Config options for the watcher (`WatcherOption`, `WithDebounce`) follow
the same pkg/config functional-options pattern used by the rest of the
library, with the watcher embedding `config.WatcherDebounce` directly.

<!--- START AUTOGENERATED NOTES --->
### Changelog ([#53](https://github.com/harrydayexe/GoBlog/pull/53))

#### ✨ New Features
- add --watch flag to goblog serve for live markdown reload

#### 🏗️ Build System
- add vulncheck to justfile

<!--- END AUTOGENERATED NOTES --->