### PR TITLE
fix(watcher): release watch descriptor on subdirectory deletion

### DIFF
--- a/pkg/watcher/doc.go
+++ b/pkg/watcher/doc.go
@@ -67,9 +67,9 @@
 // Only changes to files with a .md extension trigger the onChange callback.
 // All other file types (images, CSS, YAML, etc.) are silently ignored, as
 // are common editor temporary files (dotfiles, *.swp, *~, etc.).
-// Deletion of already-watched directories is not currently handled:
-// the watcher stops receiving events for deleted directory trees but does not
-// error. See the project issue tracker for a planned improvement.
+// Deletion of watched subdirectories releases the corresponding watch
+// descriptor automatically. A subdirectory that is removed and then recreated
+// is re-watched when the parent fires the subsequent Create event.
 //
 // # Concurrency
 //

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -109,6 +109,21 @@ func (w *Watcher) Run(ctx context.Context, onChange func(context.Context)) error
 				}
 			}
 
+			// If a watched directory was removed, release its watch
+			// descriptor. WatchList() is the single source of truth for
+			// which paths are directories vs files, since os.Stat would
+			// fail on an already-deleted path.
+			if event.Has(fsnotify.Remove) {
+				if slicesContains(w.fw.WatchList(), event.Name) {
+					if err := w.fw.Remove(event.Name); err != nil {
+						logger.DebugContext(ctx, "watcher: failed to remove watch for deleted directory", slog.String("path", event.Name), slog.Any("error", err))
+					} else {
+						logger.DebugContext(ctx, "watcher: released watch for deleted directory", slog.String("path", event.Name))
+					}
+					continue
+				}
+			}
+
 			// Only regenerate for markdown file changes.
 			if filepath.Ext(event.Name) != ".md" {
 				continue
@@ -158,6 +173,16 @@ func (w *Watcher) addDirs(path string) error {
 		slog.Default().Debug("watcher: watching directory", slog.String("path", p))
 		return nil
 	})
+}
+
+// slicesContains reports whether s contains target.
+func slicesContains(s []string, target string) bool {
+	for _, v := range s {
+		if v == target {
+			return true
+		}
+	}
+	return false
 }
 
 // isNoise reports whether a filesystem event path should be ignored.

--- a/pkg/watcher/watcher_internal_test.go
+++ b/pkg/watcher/watcher_internal_test.go
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package watcher
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/harrydayexe/GoBlog/v2/pkg/config"
+)
+
+// TestRemovedSubdirReleasesWatch verifies that deleting a watched subdirectory
+// causes its watch descriptor to be released within one event loop iteration.
+func TestRemovedSubdirReleasesWatch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "subdir")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatalf("Mkdir error = %v", err)
+	}
+
+	w, err := New(dir, config.WithDebounce(50*time.Millisecond))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	go w.Run(ctx, func(context.Context) {}) //nolint:errcheck
+
+	// Give the watcher time to start listening.
+	time.Sleep(50 * time.Millisecond)
+
+	// Confirm the subdir is currently watched.
+	if !slicesContains(w.fw.WatchList(), sub) {
+		t.Fatalf("expected %q to be in watchedDirs before removal", sub)
+	}
+
+	if err := os.Remove(sub); err != nil {
+		t.Fatalf("Remove error = %v", err)
+	}
+
+	// Poll until the watch descriptor is released (or timeout).
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if !slicesContains(w.fw.WatchList(), sub) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Errorf("%q still present in watchedDirs after removal", sub)
+}

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -205,6 +205,50 @@ func TestRun_NonMarkdownIgnored(t *testing.T) {
 	}
 }
 
+// TestRun_SubdirRemoveThenRecreateTracked verifies that removing a watched
+// subdirectory and recreating it still triggers onChange when a file is written
+// inside the new directory.
+func TestRun_SubdirRemoveThenRecreateTracked(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "subdir")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatalf("Mkdir error = %v", err)
+	}
+
+	w, err := watcher.New(dir, config.WithDebounce(shortDebounce))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	var count atomic.Int64
+	go w.Run(ctx, func(context.Context) { count.Add(1) }) //nolint:errcheck
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Remove the subdirectory.
+	if err := os.Remove(sub); err != nil {
+		t.Fatalf("Remove error = %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	// Recreate it and write a markdown file inside.
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatalf("Mkdir (recreate) error = %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if err := os.WriteFile(filepath.Join(sub, "post.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	waitForCount(t, &count, 1, 3*time.Second)
+}
+
 // TestRun_NoiseIgnored verifies that dot-files and editor swap files are ignored.
 func TestRun_NoiseIgnored(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Deleting a watched subdirectory left its OS-level watch descriptor registered until the process exited. On Linux this leaks inotify fds toward the max_user_watches limit; on macOS it leaks kqueue entries. A removed-then-recreated subdirectory would also silently stop triggering onChange for files written inside it.

On fsnotify.Remove, check whether the path is present in WatchList() (used as the single source of truth because os.Stat fails on an already-deleted path) and call fw.Remove to release the descriptor. Re-creation falls through to the existing Create branch unchanged.

Fixes #51
<!--- START AUTOGENERATED NOTES --->
### Changelog ([#54](https://github.com/harrydayexe/GoBlog/pull/54))

#### 🐛 Bug Fixes
- (watcher) release watch descriptor on subdirectory deletion

<!--- END AUTOGENERATED NOTES --->