### PR TITLE
feat(logging): unify logger injection via config.WithLogger (#52)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,10 @@ The README.md does not need to be flooded with documentation. Just the relevant 
 2. Docker image via docker pull/run
 3. The library itself
 
+## Code Style
+
+When two approaches are functionally equivalent with no performance difference, prefer the one that is easier to read and understand.
+
 ## Config Pattern
 
 All configurable values are defined as named types in `pkg/config` (e.g. `type Port int`, `type WatcherDebounce struct{ Debounce time.Duration }`). These types are **embedded directly** into the structs that consume them (`Server`, `Generator`, `Watcher`), not stored as plain unexported fields. Option constructor functions (e.g. `WithPort`, `WithLogger`) live in `pkg/config` and return an option struct with exactly one non-nil function pointer. Options are applied in an `else if` chain passing a pointer to the embedded field: `if opt.WithXFunc != nil { opt.WithXFunc(&s.X) } else if opt.WithYFunc != nil { ... }`. New configurable behaviour always follows this pattern end-to-end: config type in `pkg/config`, option function in `pkg/config`, embedded field in the consumer struct.

--- a/README.md
+++ b/README.md
@@ -138,27 +138,27 @@ Every component accepts a structured [`log/slog`](https://pkg.go.dev/log/slog) l
 ```go
 logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
-// Generator and outputter: wrap in WithBaseOption
+// Generator and outputter
 gen := generator.New(fsys, renderer,
-    config.WithBaseOption(config.WithLogger(logger)),
+    config.WithLogger(logger).AsGeneratorOption(),
 )
 writer := outputter.NewDirectoryWriter("output/",
-    config.WithBaseOption(config.WithLogger(logger)),
+    config.WithLogger(logger).AsGeneratorOption(),
 )
 
-// Server: embed in BaseServerOption
+// Server
 cfg := config.ServerConfig{
     Server: []config.BaseServerOption{
         config.WithPort(8080),
-        {BaseOption: config.WithLogger(logger)},
+        config.WithLogger(logger).AsServerOption(),
     },
 }
 srv, err := server.New(nil, postsFS, cfg)
 
-// Watcher: wrap in WithBaseWatcherOption
-w, err := watcher.New("posts/", config.WithBaseWatcherOption(config.WithLogger(logger)))
+// Watcher
+w, err := watcher.New("posts/", config.WithLogger(logger).AsWatcherOption())
 
-// Parser: use parser.WithLogger directly
+// Parser
 p := parser.New(parser.WithLogger(logger))
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,37 @@ func main() {
 }
 ```
 
+### Logger injection
+
+Every component accepts a structured [`log/slog`](https://pkg.go.dev/log/slog) logger via `config.WithLogger`. When not supplied, each component falls back to `slog.Default()` at construction time.
+
+```go
+logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+// Generator and outputter: wrap in WithBaseOption
+gen := generator.New(fsys, renderer,
+    config.WithBaseOption(config.WithLogger(logger)),
+)
+writer := outputter.NewDirectoryWriter("output/",
+    config.WithBaseOption(config.WithLogger(logger)),
+)
+
+// Server: embed in BaseServerOption
+cfg := config.ServerConfig{
+    Server: []config.BaseServerOption{
+        config.WithPort(8080),
+        {BaseOption: config.WithLogger(logger)},
+    },
+}
+srv, err := server.New(nil, postsFS, cfg)
+
+// Watcher: wrap in WithBaseWatcherOption
+w, err := watcher.New("posts/", config.WithBaseWatcherOption(config.WithLogger(logger)))
+
+// Parser: use parser.WithLogger directly
+p := parser.New(parser.WithLogger(logger))
+```
+
 Full API documentation, including all config options and template data types, is at [pkg.go.dev/github.com/harrydayexe/GoBlog/v2](https://pkg.go.dev/github.com/harrydayexe/GoBlog/v2).
 
 ## Contributing

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -81,7 +81,7 @@ func NewGeneratorCommand(ctx context.Context, c *cli.Command) error {
 		if !strings.HasSuffix(blogRoot, "/") {
 			blogRoot += "/"
 		}
-		opts = append(opts, config.WithBaseOption(config.WithBlogRoot(blogRoot)))
+		opts = append(opts, config.WithBlogRoot(blogRoot).AsGeneratorOption())
 	}
 
 	renderer, err := generator.NewTemplateRenderer(templateDir)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -314,7 +314,7 @@ Testing the blog root feature.
 	}
 
 	// Generate with custom blog root
-	opts := []config.GeneratorOption{config.WithBaseOption(config.WithBlogRoot("/blog/"))}
+	opts := []config.GeneratorOption{config.WithBlogRoot("/blog/").AsGeneratorOption()}
 	handler := outputter.NewDirectoryWriter(outputDir, opts...)
 
 	ctx := context.Background()

--- a/internal/server/command_test.go
+++ b/internal/server/command_test.go
@@ -56,7 +56,7 @@ func TestRunServe_CanceledContext(t *testing.T) {
 		Server: []config.BaseServerOption{config.WithPort(0)},
 	}
 
-	err := runServe(ctx, discardLogger(), t.TempDir(), testFS(), cfg, false)
+	err := runServe(ctx, t.TempDir(), testFS(), cfg, false)
 	if err != nil {
 		t.Errorf("runServe() with canceled context error = %v, want nil", err)
 	}
@@ -150,7 +150,7 @@ func TestRunServe_WatchBadPath(t *testing.T) {
 		Server: []config.BaseServerOption{config.WithPort(0)},
 	}
 
-	err := runServe(ctx, discardLogger(), "/nonexistent/goblog/watch/test", testFS(), cfg, true)
+	err := runServe(ctx, "/nonexistent/goblog/watch/test", testFS(), cfg, true)
 	if err == nil {
 		t.Error("runServe() with watch=true and bad path returned nil, want error")
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -90,7 +90,7 @@ func runServe(ctx context.Context, postsPath string, posts fs.FS, cfg config.Ser
 	}
 
 	if watch {
-		w, err := watcher.New(postsPath, config.WithBaseWatcherOption(config.WithLogger(slog.Default())))
+		w, err := watcher.New(postsPath, config.WithBaseWatcherOption(srv.Logger.AsOption()))
 		if err != nil {
 			return err
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -79,27 +79,28 @@ func NewServeCommand(ctx context.Context, c *cli.Command) error {
 		cfg.Gen = append(cfg.Gen, config.WithBaseOption(config.WithBlogRoot(blogRoot)))
 	}
 
-	return runServe(ctx, slog.Default(), inputPostsDir, postsFsys, cfg, c.Bool(WatchFlagName))
+	cfg.Server = append(cfg.Server, config.BaseServerOption{BaseOption: config.WithLogger(slog.Default())})
+	return runServe(ctx, inputPostsDir, postsFsys, cfg, c.Bool(WatchFlagName))
 }
 
-func runServe(ctx context.Context, logger *slog.Logger, postsPath string, posts fs.FS, cfg config.ServerConfig, watch bool) error {
-	srv, err := server.New(logger, posts, cfg)
+func runServe(ctx context.Context, postsPath string, posts fs.FS, cfg config.ServerConfig, watch bool) error {
+	srv, err := server.New(nil, posts, cfg)
 	if err != nil {
 		return err
 	}
 
 	if watch {
-		w, err := watcher.New(postsPath)
+		w, err := watcher.New(postsPath, config.WithBaseWatcherOption(config.WithLogger(slog.Default())))
 		if err != nil {
 			return err
 		}
 		go func() {
 			if err := w.Run(ctx, func(ctx context.Context) {
 				if err := srv.UpdatePosts(os.DirFS(postsPath), ctx); err != nil {
-					logger.WarnContext(ctx, "watcher: failed to reload posts", slog.Any("error", err))
+					slog.Default().WarnContext(ctx, "watcher: failed to reload posts", slog.Any("error", err))
 				}
 			}); err != nil {
-				logger.WarnContext(ctx, "watcher: stopped with error", slog.Any("error", err))
+				slog.Default().WarnContext(ctx, "watcher: stopped with error", slog.Any("error", err))
 			}
 		}()
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -75,11 +75,11 @@ func NewServeCommand(ctx context.Context, c *cli.Command) error {
 		if !strings.HasSuffix(blogRoot, "/") {
 			blogRoot += "/"
 		}
-		cfg.Server = append(cfg.Server, config.BaseServerOption{BaseOption: config.WithBlogRoot(blogRoot)})
-		cfg.Gen = append(cfg.Gen, config.WithBaseOption(config.WithBlogRoot(blogRoot)))
+		cfg.Server = append(cfg.Server, config.WithBlogRoot(blogRoot).AsServerOption())
+		cfg.Gen = append(cfg.Gen, config.WithBlogRoot(blogRoot).AsGeneratorOption())
 	}
 
-	cfg.Server = append(cfg.Server, config.BaseServerOption{BaseOption: config.WithLogger(slog.Default())})
+	cfg.Server = append(cfg.Server, config.WithLogger(slog.Default()).AsServerOption())
 	return runServe(ctx, inputPostsDir, postsFsys, cfg, c.Bool(WatchFlagName))
 }
 
@@ -90,7 +90,7 @@ func runServe(ctx context.Context, postsPath string, posts fs.FS, cfg config.Ser
 	}
 
 	if watch {
-		w, err := watcher.New(postsPath, config.WithBaseWatcherOption(srv.Logger.AsOption()))
+		w, err := watcher.New(postsPath, srv.Logger.AsOption().AsWatcherOption())
 		if err != nil {
 			return err
 		}

--- a/pkg/config/baseOption.go
+++ b/pkg/config/baseOption.go
@@ -4,6 +4,8 @@
 
 package config
 
+import "log/slog"
+
 // BaseOption represents a configuration option that can be applied to
 // many different instances during construction.
 //
@@ -12,9 +14,39 @@ package config
 // modify specific configuration fields.
 //
 // This type should not be constructed directly by users. Instead, use the
-// provided option functions like WithBlogRoot().
+// provided option functions like WithBlogRoot() or WithLogger().
 type BaseOption struct {
 	WithBlogRootFunc func(v *BlogRoot)
+	WithLoggerFunc   func(v *Logger)
+}
+
+// Logger is a configuration type that holds a [log/slog.Logger] for structured
+// logging.
+//
+// This type is typically embedded in constructor configuration structs and
+// should be set using the [WithLogger] option function. When no logger is
+// supplied, constructors fall back to [log/slog.Default] at construction time.
+type Logger struct{ Logger *slog.Logger }
+
+// WithLogger returns a BaseOption that sets the structured logger used by the
+// component.
+//
+// Passing nil is permitted and is treated the same as not supplying the option:
+// the component falls back to [log/slog.Default] at construction time.
+//
+// Example usage:
+//
+//	import "log/slog"
+//
+//	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+//
+//	gen := generator.New(fsys, renderer, config.WithLogger(logger))
+//	w, err := watcher.New("posts/", config.WithLogger(logger))
+//	writer := outputter.NewDirectoryWriter("output/", config.WithBaseOption(config.WithLogger(logger)))
+func WithLogger(l *slog.Logger) BaseOption {
+	return BaseOption{
+		WithLoggerFunc: func(v *Logger) { v.Logger = l },
+	}
 }
 
 // BlogRoot is a configuration type that holds the blog's root path

--- a/pkg/config/baseOption.go
+++ b/pkg/config/baseOption.go
@@ -42,7 +42,7 @@ type Logger struct{ Logger *slog.Logger }
 //
 //	gen := generator.New(fsys, renderer, config.WithLogger(logger))
 //	w, err := watcher.New("posts/", config.WithLogger(logger))
-//	writer := outputter.NewDirectoryWriter("output/", config.WithBaseOption(config.WithLogger(logger)))
+//	writer := outputter.NewDirectoryWriter("output/", config.WithLogger(logger).AsGeneratorOption())
 func WithLogger(l *slog.Logger) BaseOption {
 	return BaseOption{
 		WithLoggerFunc: func(v *Logger) { v.Logger = l },

--- a/pkg/config/baseOption.go
+++ b/pkg/config/baseOption.go
@@ -40,7 +40,7 @@ type Logger struct{ Logger *slog.Logger }
 //
 //	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 //
-//	gen := generator.New(fsys, renderer, config.WithLogger(logger))
+//	gen := generator.New(fsys, renderer, config.WithLogger(logger).AsGeneratorOption())
 //	w, err := watcher.New("posts/", config.WithLogger(logger))
 //	writer := outputter.NewDirectoryWriter("output/", config.WithLogger(logger).AsGeneratorOption())
 func WithLogger(l *slog.Logger) BaseOption {

--- a/pkg/config/baseOption.go
+++ b/pkg/config/baseOption.go
@@ -70,6 +70,16 @@ func WithBlogRoot(root string) BaseOption {
 	}
 }
 
+// AsOption returns a BaseOption that re-applies this BlogRoot value to another
+// component, enabling a resolved blog root to be forwarded to sub-components
+// without reaching into its underlying string.
 func (o BlogRoot) AsOption() BaseOption {
 	return WithBlogRoot(string(o))
+}
+
+// AsOption returns a BaseOption that re-applies this Logger value to another
+// component, enabling a resolved logger to be forwarded to sub-components
+// without reaching into its underlying [log/slog.Logger].
+func (o Logger) AsOption() BaseOption {
+	return WithLogger(o.Logger)
 }

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -53,6 +53,14 @@
 // deploying at example.com/blog/. This ensures all generated links in templates
 // use the correct base path. Default is "/" for root deployment.
 //
+// WithLogger(l *slog.Logger) is a BaseOption that sets the structured logger
+// used by the receiving component. It flows into every constructor that
+// accepts BaseOption values (generator.New via GeneratorOption, server.New via
+// BaseServerOption, outputter.NewDirectoryWriter via GeneratorOption) and into
+// watcher.New via WatcherOption (which embeds BaseOption). When not supplied,
+// each constructor falls back to slog.Default() at construction time. Passing
+// nil has the same effect as omitting the option.
+//
 // WithFuncs(funcs template.FuncMap) is a RendererOption that registers
 // additional template functions for use in all templates. Functions are merged
 // into the built-in FuncMap (formatDate, shortDate, year). A function whose
@@ -78,8 +86,12 @@
 //
 // GeneratorOption carries options for generator.New and outputter.NewDirectoryWriter,
 // including WithRawOutput, WithDisableTags, WithDisableReadingTime, WithSiteTitle,
-// WithEnvironment, WithCustomData, and WithHTMLPaths.
-// BaseServerOption carries options for the HTTP server (port, host, middleware).
+// WithEnvironment, WithCustomData, WithHTMLPaths, and (via the embedded BaseOption)
+// WithLogger and WithBlogRoot.
+// BaseServerOption carries options for the HTTP server (port, host, middleware,
+// and via the embedded BaseOption: WithLogger, WithBlogRoot).
+// WatcherOption carries options for watcher.New (debounce, and via the embedded
+// BaseOption: WithLogger, WithBlogRoot).
 // RendererOption carries options for generator.NewTemplateRenderer (custom funcs).
 // ServerConfig groups all three option types plus a TemplateDir filesystem for
 // the server constructor (server.New).

--- a/pkg/config/generatorOption.go
+++ b/pkg/config/generatorOption.go
@@ -14,7 +14,7 @@ package config
 // This type should not be constructed directly by users. Instead, use the
 // provided option functions like WithRawOutput(), WithDisableTags(),
 // WithDisableReadingTime(), WithSiteTitle(), WithEnvironment(), WithCustomData(),
-// and WithBaseOption().
+// or call [BaseOption.AsGeneratorOption] on a [BaseOption] value.
 type GeneratorOption struct {
 	BaseOption
 
@@ -29,11 +29,21 @@ type GeneratorOption struct {
 
 // WithBaseOption wraps a BaseOption as a GeneratorOption so it can be passed
 // to generator constructors that accept GeneratorOption values.
-// Use this when you have a BaseOption (e.g. from WithBlogRoot) and need to
-// supply it alongside other GeneratorOptions.
+//
+// Deprecated: call [BaseOption.AsGeneratorOption] directly instead.
 func WithBaseOption(baseOption BaseOption) GeneratorOption {
 	return GeneratorOption{
 		BaseOption: baseOption,
+	}
+}
+
+// AsGeneratorOption returns a GeneratorOption that applies this BaseOption to a
+// generator or outputter instance, enabling a BaseOption (e.g. from [WithLogger]
+// or [WithBlogRoot]) to be passed to generator constructors alongside other
+// GeneratorOptions.
+func (o BaseOption) AsGeneratorOption() GeneratorOption {
+	return GeneratorOption{
+		BaseOption: o,
 	}
 }
 

--- a/pkg/config/option.go
+++ b/pkg/config/option.go
@@ -4,6 +4,14 @@
 
 package config
 
+// Option is implemented by resolved configuration value types that can
+// convert themselves back into a functional option of type T.
+//
+// This allows a value that has already been applied to one component to be
+// forwarded to another without unpacking its underlying fields. For example,
+// [BlogRoot] and [Logger] both implement Option[BaseOption], so a server can
+// forward its resolved BlogRoot or Logger to a sub-component by calling
+// AsOption() rather than constructing a new option from scratch.
 type Option[T any] interface {
 	AsOption() T
 }

--- a/pkg/config/serverOption.go
+++ b/pkg/config/serverOption.go
@@ -11,7 +11,8 @@ import "github.com/harrydayexe/GoWebUtilities/middleware"
 // pointer that modifies a specific server setting.
 //
 // This type should not be constructed directly. Use the provided option
-// functions: WithPort, WithHost, and WithMiddleware.
+// functions: [WithPort], [WithHost], [WithMiddleware], or call
+// [BaseOption.AsServerOption] on a [BaseOption] value (e.g. from [WithLogger]).
 type BaseServerOption struct {
 	BaseOption
 
@@ -86,5 +87,15 @@ func WithMiddleware(mw ...middleware.Middleware) BaseServerOption {
 		WithMiddlewareFunc: func(middleware *[]middleware.Middleware) {
 			*middleware = append(*middleware, mw...)
 		},
+	}
+}
+
+// AsServerOption returns a BaseServerOption that applies this BaseOption to a
+// server instance, enabling a BaseOption (e.g. from [WithLogger] or
+// [WithBlogRoot]) to be passed to server constructors alongside other
+// server options.
+func (o BaseOption) AsServerOption() BaseServerOption {
+	return BaseServerOption{
+		BaseOption: o,
 	}
 }

--- a/pkg/config/watcherOption.go
+++ b/pkg/config/watcherOption.go
@@ -11,8 +11,8 @@ import "time"
 // pointer that modifies a specific watcher setting.
 //
 // This type should not be constructed directly. Use the provided option
-// functions: WithDebounce, or the inherited [BaseOption] functions such as
-// [WithLogger].
+// functions: [WithDebounce], or call [BaseOption.AsWatcherOption] on a
+// [BaseOption] value (e.g. from [WithLogger]).
 type WatcherOption struct {
 	BaseOption
 
@@ -37,12 +37,11 @@ func WithDebounce(d time.Duration) WatcherOption {
 	}
 }
 
-// WithBaseWatcherOption wraps a [BaseOption] as a [WatcherOption] so it can be
-// passed to watcher constructors that accept [WatcherOption] values.
-// Use this when you have a BaseOption (e.g. from [WithLogger]) and need to
-// supply it alongside other WatcherOptions.
-func WithBaseWatcherOption(baseOption BaseOption) WatcherOption {
+// AsWatcherOption returns a WatcherOption that applies this BaseOption to a
+// watcher instance, enabling a BaseOption (e.g. from [WithLogger]) to be
+// passed to watcher constructors alongside other WatcherOptions.
+func (o BaseOption) AsWatcherOption() WatcherOption {
 	return WatcherOption{
-		BaseOption: baseOption,
+		BaseOption: o,
 	}
 }

--- a/pkg/config/watcherOption.go
+++ b/pkg/config/watcherOption.go
@@ -11,8 +11,11 @@ import "time"
 // pointer that modifies a specific watcher setting.
 //
 // This type should not be constructed directly. Use the provided option
-// functions: WithDebounce.
+// functions: WithDebounce, or the inherited [BaseOption] functions such as
+// [WithLogger].
 type WatcherOption struct {
+	BaseOption
+
 	WithDebounceFunc func(v *WatcherDebounce)
 }
 
@@ -31,5 +34,15 @@ type WatcherDebounce struct{ Debounce time.Duration }
 func WithDebounce(d time.Duration) WatcherOption {
 	return WatcherOption{
 		WithDebounceFunc: func(v *WatcherDebounce) { v.Debounce = d },
+	}
+}
+
+// WithBaseWatcherOption wraps a [BaseOption] as a [WatcherOption] so it can be
+// passed to watcher constructors that accept [WatcherOption] values.
+// Use this when you have a BaseOption (e.g. from [WithLogger]) and need to
+// supply it alongside other WatcherOptions.
+func WithBaseWatcherOption(baseOption BaseOption) WatcherOption {
+	return WatcherOption{
+		BaseOption: baseOption,
 	}
 }

--- a/pkg/generator/doc.go
+++ b/pkg/generator/doc.go
@@ -38,6 +38,15 @@
 //
 //	gen := generator.New(fsys, nil, config.WithRawOutput())
 //
+// # Logger injection
+//
+// Supply a structured logger via config.WithLogger (a BaseOption, so it must be
+// wrapped with config.WithBaseOption when passed to generator.New):
+//
+//	gen := generator.New(fsys, renderer,
+//	    config.WithBaseOption(config.WithLogger(myLogger)),
+//	)
+//
 // # Custom Template Functions
 //
 // Additional template functions can be registered via [config.WithFuncs] and

--- a/pkg/generator/doc.go
+++ b/pkg/generator/doc.go
@@ -40,11 +40,11 @@
 //
 // # Logger injection
 //
-// Supply a structured logger via config.WithLogger (a BaseOption, so it must be
-// wrapped with config.WithBaseOption when passed to generator.New):
+// Supply a structured logger via config.WithLogger (a BaseOption, so call
+// AsGeneratorOption to pass it to generator.New):
 //
 //	gen := generator.New(fsys, renderer,
-//	    config.WithBaseOption(config.WithLogger(myLogger)),
+//	    config.WithLogger(myLogger).AsGeneratorOption(),
 //	)
 //
 // # Custom Template Functions

--- a/pkg/generator/examples_test.go
+++ b/pkg/generator/examples_test.go
@@ -121,7 +121,7 @@ func ExampleWithBlogRoot() {
 
 	// Set blog root for deployment at /blog/ subdirectory
 	// This ensures all links in templates use /blog/ as the base path
-	gen := generator.New(fsys, nil, config.WithBaseOption(config.WithBlogRoot("/blog/")), config.WithRawOutput())
+	gen := generator.New(fsys, nil, config.WithBlogRoot("/blog/").AsGeneratorOption(), config.WithRawOutput())
 
 	ctx := context.Background()
 	blog, err := gen.Generate(ctx)

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -35,9 +35,9 @@ type Generator struct {
 	config.Environment
 	config.CustomData
 	config.HTMLPaths
+	config.Logger
 	ParserConfig parser.Config // The config to use when parsing
 
-	logger   *slog.Logger
 	renderer *TemplateRenderer
 }
 
@@ -71,11 +71,8 @@ func (c Generator) String() string {
 // config.WithBlogRoot, config.WithEnvironment, config.WithCustomData.
 // The template renderer is supplied as a positional argument, not an option.
 func New(posts fs.FS, renderer *TemplateRenderer, opts ...config.GeneratorOption) *Generator {
-	logger := slog.Default()
-
 	gen := Generator{
 		PostsDir: posts,
-		logger:   logger,
 		renderer: renderer,
 		BlogRoot: config.BlogRoot("/"),
 	}
@@ -98,7 +95,13 @@ func New(posts fs.FS, renderer *TemplateRenderer, opts ...config.GeneratorOption
 			opt.WithCustomDataFunc(&gen.CustomData)
 		} else if opt.WithHTMLPathsFunc != nil {
 			opt.WithHTMLPathsFunc(&gen.HTMLPaths)
+		} else if opt.WithLoggerFunc != nil {
+			opt.WithLoggerFunc(&gen.Logger)
 		}
+	}
+
+	if gen.Logger.Logger == nil {
+		gen.Logger.Logger = slog.Default()
 	}
 
 	if gen.SiteTitle.SiteTitle == "" {
@@ -142,8 +145,10 @@ func New(posts fs.FS, renderer *TemplateRenderer, opts ...config.GeneratorOption
 // It returns an error if markdown files cannot be read, parsing fails, or
 // template rendering encounters an error.
 func (g *Generator) Generate(ctx context.Context) (*GeneratedBlog, error) {
-	g.logger.DebugContext(ctx, "Creating parser for generate call")
-	p := parser.NewWithConfig(&g.ParserConfig)
+	g.Logger.Logger.DebugContext(ctx, "Creating parser for generate call")
+	parserCfg := g.ParserConfig
+	parserCfg.Logger = g.Logger.Logger
+	p := parser.NewWithConfig(&parserCfg)
 
 	posts, err := p.ParseDirectory(ctx, g.PostsDir)
 	if err != nil {
@@ -152,7 +157,7 @@ func (g *Generator) Generate(ctx context.Context) (*GeneratedBlog, error) {
 
 	// Step 2: If RawOutput mode, return immediately with raw HTML
 	if g.RawOutput.RawOutput {
-		g.logger.InfoContext(ctx, "Raw output enabled, ignoring templates")
+		g.Logger.Logger.InfoContext(ctx, "Raw output enabled, ignoring templates")
 		return g.assembleRawBlog(posts), nil
 	}
 
@@ -170,7 +175,7 @@ func (g *Generator) Generate(ctx context.Context) (*GeneratedBlog, error) {
 // The log output will only appear if the logger is configured to show debug
 // level messages.
 func (g *Generator) DebugConfig(ctx context.Context) {
-	g.logger.DebugContext(ctx, g.String())
+	g.Logger.Logger.DebugContext(ctx, g.String())
 }
 
 // pagePath returns the BaseData.Path value for a given page.
@@ -218,7 +223,7 @@ func (g *Generator) assembleRawBlog(posts models.PostList) *GeneratedBlog {
 }
 
 func (g *Generator) assembleBlogWithTemplates(ctx context.Context, posts models.PostList) (*GeneratedBlog, error) {
-	g.logger.DebugContext(ctx, "Rendering posts with templates")
+	g.Logger.Logger.DebugContext(ctx, "Rendering posts with templates")
 
 	// Check if renderer is available
 	if g.renderer == nil {

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"html/template"
 	"io/fs"
+	"log/slog"
 	"os"
 	"strings"
 	"testing"
@@ -57,7 +58,7 @@ func TestNew(t *testing.T) {
 			}
 
 			if gen != nil {
-				if gen.logger == nil {
+				if gen.Logger.Logger == nil {
 					t.Error("New() returned generator with nil logger")
 				}
 			}
@@ -1490,6 +1491,21 @@ func TestGenerator_CustomData_Merge(t *testing.T) {
 	}
 	if data["c"] != "gamma" {
 		t.Errorf("Expected 'c' = %q; got %v", "gamma", data["c"])
+	}
+}
+
+// TestNew_WithLogger verifies that a logger injected via config.WithLogger is
+// stored on the Generator and takes precedence over the slog.Default() fallback.
+func TestNew_WithLogger(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	injected := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	gen := New(os.DirFS("testdata"), nil, config.WithBaseOption(config.WithLogger(injected)))
+
+	if gen.Logger.Logger != injected {
+		t.Error("WithLogger option was not applied: generator logger does not match injected logger")
 	}
 }
 

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -690,7 +690,7 @@ func TestGenerate_WithCustomBlogRoot(t *testing.T) {
 	}
 
 	// Create generator with custom blog root
-	gen := New(testFS, renderer, config.WithBaseOption(config.WithBlogRoot("/blog/")))
+	gen := New(testFS, renderer, config.WithBlogRoot("/blog/").AsGeneratorOption())
 
 	ctx := context.Background()
 	blog, err := gen.Generate(ctx)
@@ -814,7 +814,7 @@ func TestWithBlogRoot(t *testing.T) {
 	}
 
 	// With option - should use provided blog root
-	genCustom := New(testFS, nil, config.WithBaseOption(config.WithBlogRoot("/blog/")))
+	genCustom := New(testFS, nil, config.WithBlogRoot("/blog/").AsGeneratorOption())
 	if genCustom.BlogRoot != "/blog/" {
 		t.Errorf("Generator with WithBlogRoot() has BlogRoot = %q, want %q",
 			genCustom.BlogRoot, "/blog/")
@@ -1161,7 +1161,7 @@ func TestGenerate_PathInTemplateData(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			opts := []config.GeneratorOption{config.WithBaseOption(config.WithBlogRoot(tt.blogRoot))}
+			opts := []config.GeneratorOption{config.WithBlogRoot(tt.blogRoot).AsGeneratorOption()}
 			if tt.htmlPaths {
 				opts = append(opts, config.WithHTMLPaths())
 			}
@@ -1502,7 +1502,7 @@ func TestNew_WithLogger(t *testing.T) {
 	var buf bytes.Buffer
 	injected := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	gen := New(os.DirFS("testdata"), nil, config.WithBaseOption(config.WithLogger(injected)))
+	gen := New(os.DirFS("testdata"), nil, config.WithLogger(injected).AsGeneratorOption())
 
 	if gen.Logger.Logger != injected {
 		t.Error("WithLogger option was not applied: generator logger does not match injected logger")

--- a/pkg/outputter/directoryWriter.go
+++ b/pkg/outputter/directoryWriter.go
@@ -26,8 +26,8 @@ import (
 type DirectoryWriter struct {
 	config.RawOutput
 	config.DisableTags
+	config.Logger
 	outputDir string
-	logger    *slog.Logger
 }
 
 // NewDirectoryWriter creates a new DirectoryWriter with the specified output
@@ -48,11 +48,8 @@ type DirectoryWriter struct {
 //
 // This is the recommended constructor for most use cases.
 func NewDirectoryWriter(outputDir string, opts ...config.GeneratorOption) DirectoryWriter {
-	logger := slog.Default()
-
 	dw := DirectoryWriter{
 		outputDir: outputDir,
-		logger:    logger,
 	}
 
 	for _, opt := range opts {
@@ -60,10 +57,16 @@ func NewDirectoryWriter(outputDir string, opts ...config.GeneratorOption) Direct
 			opt.WithRawOutputFunc(&dw.RawOutput)
 		} else if opt.WithDisableTagsFunc != nil {
 			opt.WithDisableTagsFunc(&dw.DisableTags)
+		} else if opt.WithLoggerFunc != nil {
+			opt.WithLoggerFunc(&dw.Logger)
 		}
 	}
 
-	logger.Debug("Directory Writer created", slog.String("output directory", outputDir))
+	if dw.Logger.Logger == nil {
+		dw.Logger.Logger = slog.Default()
+	}
+
+	dw.Logger.Logger.Debug("Directory Writer created", slog.String("output directory", outputDir))
 
 	return dw
 }
@@ -103,7 +106,7 @@ func NewDirectoryWriter(outputDir string, opts ...config.GeneratorOption) Direct
 // writes, consider writing to a temporary directory first and renaming it
 // on success.
 func (dw DirectoryWriter) HandleGeneratedBlog(ctx context.Context, blog *generator.GeneratedBlog) error {
-	dw.logger.InfoContext(ctx, "Writing blog to directory")
+	dw.Logger.Logger.InfoContext(ctx, "Writing blog to directory")
 	if err := writeMapToFiles(blog.Posts, filepath.Join(dw.outputDir, "posts")); err != nil {
 		return err
 	}
@@ -126,7 +129,7 @@ func (dw DirectoryWriter) HandleGeneratedBlog(ctx context.Context, blog *generat
 		}
 	}
 
-	dw.logger.InfoContext(ctx, "Finished writing to output directory")
+	dw.Logger.Logger.InfoContext(ctx, "Finished writing to output directory")
 	return nil
 }
 

--- a/pkg/outputter/directoryWriter_test.go
+++ b/pkg/outputter/directoryWriter_test.go
@@ -5,7 +5,9 @@
 package outputter
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,6 +15,21 @@ import (
 	"github.com/harrydayexe/GoBlog/v2/pkg/config"
 	"github.com/harrydayexe/GoBlog/v2/pkg/generator"
 )
+
+// TestNewDirectoryWriter_WithLogger verifies that a logger injected via
+// config.WithLogger (wrapped in WithBaseOption) is stored on the DirectoryWriter.
+func TestNewDirectoryWriter_WithLogger(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	injected := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	dw := NewDirectoryWriter(t.TempDir(), config.WithBaseOption(config.WithLogger(injected)))
+
+	if dw.Logger.Logger != injected {
+		t.Error("WithLogger option was not applied: DirectoryWriter logger does not match injected logger")
+	}
+}
 
 // TestNewDirectoryWriter tests basic construction with and without options.
 func TestNewDirectoryWriter(t *testing.T) {

--- a/pkg/outputter/directoryWriter_test.go
+++ b/pkg/outputter/directoryWriter_test.go
@@ -17,14 +17,14 @@ import (
 )
 
 // TestNewDirectoryWriter_WithLogger verifies that a logger injected via
-// config.WithLogger (wrapped in WithBaseOption) is stored on the DirectoryWriter.
+// config.WithLogger is stored on the DirectoryWriter.
 func TestNewDirectoryWriter_WithLogger(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
 	injected := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	dw := NewDirectoryWriter(t.TempDir(), config.WithBaseOption(config.WithLogger(injected)))
+	dw := NewDirectoryWriter(t.TempDir(), config.WithLogger(injected).AsGeneratorOption())
 
 	if dw.Logger.Logger != injected {
 		t.Error("WithLogger option was not applied: DirectoryWriter logger does not match injected logger")

--- a/pkg/outputter/doc.go
+++ b/pkg/outputter/doc.go
@@ -59,6 +59,12 @@
 //
 // When RawOutput is enabled, the tags directory is not created.
 //
+// Inject a structured logger via config.WithLogger (wrapped in WithBaseOption):
+//
+//	writer := outputter.NewDirectoryWriter("output/",
+//	    config.WithBaseOption(config.WithLogger(myLogger)),
+//	)
+//
 // # Concurrency
 //
 // Outputter implementations should be safe for concurrent use. DirectoryWriter

--- a/pkg/outputter/doc.go
+++ b/pkg/outputter/doc.go
@@ -59,10 +59,10 @@
 //
 // When RawOutput is enabled, the tags directory is not created.
 //
-// Inject a structured logger via config.WithLogger (wrapped in WithBaseOption):
+// Inject a structured logger via config.WithLogger:
 //
 //	writer := outputter.NewDirectoryWriter("output/",
-//	    config.WithBaseOption(config.WithLogger(myLogger)),
+//	    config.WithLogger(myLogger).AsGeneratorOption(),
 //	)
 //
 // # Concurrency

--- a/pkg/parser/config.go
+++ b/pkg/parser/config.go
@@ -4,6 +4,8 @@
 
 package parser
 
+import "log/slog"
+
 // Config contains all the options for the Parser to use when reading and
 // parsing markdown files.
 type Config struct {
@@ -14,4 +16,8 @@ type Config struct {
 	// EnableFootnote controls whether the parser should allow the use of PHP
 	// Markdown Extra Footnotes.
 	EnableFootnote bool
+
+	// Logger is the structured logger used by the parser. When nil,
+	// [log/slog.Default] is used.
+	Logger *slog.Logger
 }

--- a/pkg/parser/doc.go
+++ b/pkg/parser/doc.go
@@ -43,10 +43,14 @@
 //	// Enable footnote support
 //	p := parser.New(parser.WithFootnote())
 //
+//	// Inject a structured logger
+//	p := parser.New(parser.WithLogger(myLogger))
+//
 //	// Combine multiple options
 //	p := parser.New(
 //	    parser.WithCodeHighlighting(true),
 //	    parser.WithFootnote(),
+//	    parser.WithLogger(myLogger),
 //	)
 //
 // See the Option functions for all available configuration options.

--- a/pkg/parser/option.go
+++ b/pkg/parser/option.go
@@ -4,8 +4,23 @@
 
 package parser
 
+import "log/slog"
+
 // Option is a function which can update the parser config
 type Option func(*Config)
+
+// WithLogger returns an Option that sets the structured logger used by the
+// parser. When not supplied, the parser falls back to [log/slog.Default] at
+// construction time.
+//
+// Example usage:
+//
+//	p := parser.New(parser.WithLogger(myLogger))
+func WithLogger(l *slog.Logger) Option {
+	return func(c *Config) {
+		c.Logger = l
+	}
+}
 
 // WithCodeHighlighting enables or disables the highlighting of ringfenced
 // code blocks. Highlighting is enabled by default.

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/chroma/v2/formatters/html"
+	goblogconfig "github.com/harrydayexe/GoBlog/v2/pkg/config"
 	"github.com/harrydayexe/GoBlog/v2/pkg/models"
 	"github.com/yuin/goldmark"
 	highlighting "github.com/yuin/goldmark-highlighting/v2"
@@ -29,7 +30,7 @@ import (
 type Parser struct {
 	md     goldmark.Markdown
 	config *Config
-	logger *slog.Logger
+	goblogconfig.Logger
 }
 
 // New creates a new Parser with the specified options.
@@ -82,8 +83,13 @@ func NewWithConfig(config *Config) *Parser {
 	)
 
 	p := &Parser{
-		md:     md,
-		logger: slog.Default(),
+		md: md,
+	}
+
+	if config.Logger != nil {
+		p.Logger.Logger = config.Logger
+	} else {
+		p.Logger.Logger = slog.Default()
 	}
 
 	return p
@@ -100,7 +106,7 @@ func NewWithConfig(config *Config) *Parser {
 // Returns an error if the file cannot be read, frontmatter is invalid,
 // required fields are missing, or markdown rendering fails.
 func (p *Parser) ParseFile(ctx context.Context, fsys fs.FS, path string) (*models.Post, error) {
-	p.logger.InfoContext(ctx, fmt.Sprintf("Parsing file %s...", path))
+	p.Logger.Logger.InfoContext(ctx, fmt.Sprintf("Parsing file %s...", path))
 	// Read file contents
 	content, err := fs.ReadFile(fsys, path)
 	if err != nil {
@@ -162,7 +168,7 @@ func (p *Parser) ParseFile(ctx context.Context, fsys fs.FS, path string) (*model
 // Only files with .md or .markdown extensions are processed. Other files
 // and directories are silently skipped.
 func (p *Parser) ParseDirectory(ctx context.Context, fsys fs.FS) (models.PostList, error) {
-	p.logger.InfoContext(ctx, "Parsing posts")
+	p.Logger.Logger.InfoContext(ctx, "Parsing posts")
 	var posts models.PostList
 	var parseErrors ParseErrors
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -5,12 +5,29 @@
 package parser
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"testing"
 )
+
+// TestNew_WithLogger verifies that a logger injected via parser.WithLogger
+// is stored on the Parser and takes precedence over slog.Default().
+func TestNew_WithLogger(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	injected := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	p := New(WithLogger(injected))
+
+	if p.Logger.Logger != injected {
+		t.Error("WithLogger option was not applied: parser logger does not match injected logger")
+	}
+}
 
 func TestParseFile_ValidPost(t *testing.T) {
 	t.Parallel()

--- a/pkg/server/doc.go
+++ b/pkg/server/doc.go
@@ -28,7 +28,7 @@
 //	cfg := config.ServerConfig{
 //	    Server: []config.BaseServerOption{
 //	        config.WithPort(8080),
-//	        config.BaseServerOption{BaseOption: config.WithLogger(logger)},
+//	        config.WithLogger(logger).AsServerOption(),
 //	    },
 //	}
 //
@@ -72,7 +72,7 @@
 //	    Server: []config.BaseServerOption{
 //	        config.WithPort(8080),
 //	        config.WithMiddleware(logging.New(logger)),
-//	        config.BaseServerOption{BaseOption: config.WithLogger(logger)},
+//	        config.WithLogger(logger).AsServerOption(),
 //	    },
 //	}
 //
@@ -125,7 +125,7 @@
 // a callback (debounced) on each change:
 //
 //	postsPath := "posts/"
-//	w, err := watcher.New(postsPath, config.WithBaseWatcherOption(config.WithLogger(logger)))
+//	w, err := watcher.New(postsPath, config.WithLogger(logger).AsWatcherOption())
 //	if err != nil {
 //	    log.Fatal(err)
 //	}

--- a/pkg/server/doc.go
+++ b/pkg/server/doc.go
@@ -28,10 +28,11 @@
 //	cfg := config.ServerConfig{
 //	    Server: []config.BaseServerOption{
 //	        config.WithPort(8080),
+//	        config.BaseServerOption{BaseOption: config.WithLogger(logger)},
 //	    },
 //	}
 //
-//	srv, err := server.New(logger, postsFS, cfg)
+//	srv, err := server.New(nil, postsFS, cfg)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
@@ -71,10 +72,11 @@
 //	    Server: []config.BaseServerOption{
 //	        config.WithPort(8080),
 //	        config.WithMiddleware(logging.New(logger)),
+//	        config.BaseServerOption{BaseOption: config.WithLogger(logger)},
 //	    },
 //	}
 //
-//	srv, err := server.New(logger, postsFS, cfg)
+//	srv, err := server.New(nil, postsFS, cfg)
 //
 // Custom middleware can be added following the standard pattern:
 //
@@ -123,7 +125,7 @@
 // a callback (debounced) on each change:
 //
 //	postsPath := "posts/"
-//	w, err := watcher.New(postsPath, watcher.WithLogger(logger))
+//	w, err := watcher.New(postsPath, config.WithBaseWatcherOption(config.WithLogger(logger)))
 //	if err != nil {
 //	    log.Fatal(err)
 //	}

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -19,14 +19,12 @@ import (
 // It embeds config.BlogRoot to specify the root path where the blog is served.
 type HandlerConfig struct {
 	config.BlogRoot
-
-	logger *slog.Logger
+	config.Logger
 }
 
 // Handler creates an HTTP handler that serves the generated blog content.
-// It accepts a GeneratedBlog, a logger for error reporting, and optional
-// configuration options to customize the handler behavior, such as setting
-// a custom blog root path.
+// It accepts a GeneratedBlog and optional configuration options to customize
+// the handler behavior, such as setting a custom blog root path or logger.
 //
 // The handler serves the following routes (assuming default root "/"):
 //   - GET / and GET /posts - serves the blog index page
@@ -44,15 +42,35 @@ type HandlerConfig struct {
 //
 // The handler is safe for concurrent use by multiple goroutines.
 // It does not modify the GeneratedBlog instance.
+//
+// # Logger
+//
+// Supply a logger via [config.WithLogger] in opts:
+//
+//	h := server.Handler(blog, nil, config.WithLogger(myLogger), config.WithBlogRoot("/blog/"))
+//
+// Deprecated: the positional logger parameter will be removed in v3.0.0.
+// Pass nil and supply the logger via config.WithLogger in opts instead.
+// When both are provided, the config.WithLogger option takes precedence.
 func Handler(blog *generator.GeneratedBlog, logger *slog.Logger, opts ...config.BaseOption) http.Handler {
 	cfg := HandlerConfig{
 		BlogRoot: config.BlogRoot("/"),
-		logger:   logger,
 	}
 
 	for _, opt := range opts {
 		if opt.WithBlogRootFunc != nil {
 			opt.WithBlogRootFunc(&cfg.BlogRoot)
+		} else if opt.WithLoggerFunc != nil {
+			opt.WithLoggerFunc(&cfg.Logger)
+		}
+	}
+
+	// Precedence: WithLogger option > positional logger arg > slog.Default().
+	if cfg.Logger.Logger == nil {
+		if logger != nil {
+			cfg.Logger.Logger = logger
+		} else {
+			cfg.Logger.Logger = slog.Default()
 		}
 	}
 
@@ -63,8 +81,8 @@ func Handler(blog *generator.GeneratedBlog, logger *slog.Logger, opts ...config.
 		cfg.BlogRoot = config.BlogRoot("/" + trimmed)
 	}
 
-	logger.Debug("handlerConfig set", slog.String("BlogRoot", string(cfg.BlogRoot)))
-	logger.Debug("blog index page", slog.Int("bytes", len(blog.Index)))
+	cfg.Logger.Logger.Debug("handlerConfig set", slog.String("BlogRoot", string(cfg.BlogRoot)))
+	cfg.Logger.Logger.Debug("blog index page", slog.Int("bytes", len(blog.Index)))
 
 	return middleware.NewStripHTMLExtension()(generateHandler(cfg, blog))
 }
@@ -73,7 +91,7 @@ func generateHandler(cfg HandlerConfig, blog *generator.GeneratedBlog) http.Hand
 	mux := http.NewServeMux()
 
 	root := fmt.Sprintf("GET %s/", cfg.BlogRoot)
-	cfg.logger.Debug("mux root set", slog.String("root", root))
+	cfg.Logger.Logger.Debug("mux root set", slog.String("root", root))
 	mux.Handle(root+"posts", handleIndex(cfg, blog))
 	mux.Handle(root+"{$}", handleIndex(cfg, blog))
 	mux.Handle(root+"posts/{postName}", handlePost(cfg, blog))
@@ -88,11 +106,11 @@ func generateHandler(cfg HandlerConfig, blog *generator.GeneratedBlog) http.Hand
 
 func handleIndex(cfg HandlerConfig, blog *generator.GeneratedBlog) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cfg.logger.DebugContext(r.Context(), "handling index page", slog.Int("bytes", len(blog.Index)))
+		cfg.Logger.Logger.DebugContext(r.Context(), "handling index page", slog.Int("bytes", len(blog.Index)))
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		if _, err := w.Write(blog.Index); err != nil {
-			cfg.logger.ErrorContext(r.Context(), "failed to write index", "error", err)
+			cfg.Logger.Logger.ErrorContext(r.Context(), "failed to write index", "error", err)
 			return
 		}
 	})
@@ -100,7 +118,7 @@ func handleIndex(cfg HandlerConfig, blog *generator.GeneratedBlog) http.Handler 
 
 func handlePost(cfg HandlerConfig, blog *generator.GeneratedBlog) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cfg.logger.DebugContext(r.Context(), "handling post page")
+		cfg.Logger.Logger.DebugContext(r.Context(), "handling post page")
 
 		postName := strings.TrimSuffix(r.PathValue("postName"), ".html")
 		bits, prs := blog.Posts[postName]
@@ -109,11 +127,11 @@ func handlePost(cfg HandlerConfig, blog *generator.GeneratedBlog) http.Handler {
 			return
 		}
 
-		cfg.logger.DebugContext(r.Context(), "resolved post name", slog.String("postName", postName))
+		cfg.Logger.Logger.DebugContext(r.Context(), "resolved post name", slog.String("postName", postName))
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		if _, err := w.Write(bits); err != nil {
-			cfg.logger.ErrorContext(r.Context(), "failed to write post", "error", err, "post", postName)
+			cfg.Logger.Logger.ErrorContext(r.Context(), "failed to write post", "error", err, "post", postName)
 			return
 		}
 	})
@@ -121,11 +139,11 @@ func handlePost(cfg HandlerConfig, blog *generator.GeneratedBlog) http.Handler {
 
 func handleTagsIndex(cfg HandlerConfig, blog *generator.GeneratedBlog) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cfg.logger.DebugContext(r.Context(), "handling tag index")
+		cfg.Logger.Logger.DebugContext(r.Context(), "handling tag index")
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		if _, err := w.Write(blog.TagsIndex); err != nil {
-			cfg.logger.ErrorContext(r.Context(), "failed to write tags index", "error", err)
+			cfg.Logger.Logger.ErrorContext(r.Context(), "failed to write tags index", "error", err)
 			return
 		}
 	})
@@ -133,7 +151,7 @@ func handleTagsIndex(cfg HandlerConfig, blog *generator.GeneratedBlog) http.Hand
 
 func handleTag(cfg HandlerConfig, blog *generator.GeneratedBlog) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cfg.logger.DebugContext(r.Context(), "handling tag page")
+		cfg.Logger.Logger.DebugContext(r.Context(), "handling tag page")
 
 		tagName := strings.TrimSuffix(r.PathValue("tagName"), ".html")
 		bits, prs := blog.Tags[tagName]
@@ -142,11 +160,11 @@ func handleTag(cfg HandlerConfig, blog *generator.GeneratedBlog) http.Handler {
 			return
 		}
 
-		cfg.logger.DebugContext(r.Context(), "resolved tag name", slog.String("tagName", tagName))
+		cfg.Logger.Logger.DebugContext(r.Context(), "resolved tag name", slog.String("tagName", tagName))
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		if _, err := w.Write(bits); err != nil {
-			cfg.logger.ErrorContext(r.Context(), "failed to write tag page", "error", err, "tag", tagName)
+			cfg.Logger.Logger.ErrorContext(r.Context(), "failed to write tag page", "error", err, "tag", tagName)
 			return
 		}
 	})

--- a/pkg/server/logger_test.go
+++ b/pkg/server/logger_test.go
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package server
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/harrydayexe/GoBlog/v2/pkg/config"
+)
+
+func makeInternalTestFS(t *testing.T) fstest.MapFS {
+	t.Helper()
+	return fstest.MapFS{
+		"test-post.md": &fstest.MapFile{
+			Data: []byte(strings.TrimSpace(`
+---
+title: Test Post
+description: A test post
+date: 2024-01-01
+---
+
+# Test Content
+`)),
+		},
+	}
+}
+
+// TestServer_LoggerPropagatedToGenerator verifies that the server's resolved
+// logger is forwarded into the internal generator it constructs.
+func TestServer_LoggerPropagatedToGenerator(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	injected := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	postsFS := makeInternalTestFS(t)
+	cfg := config.ServerConfig{
+		Server: []config.BaseServerOption{
+			{BaseOption: config.WithLogger(injected)},
+		},
+		Gen: []config.GeneratorOption{config.WithRawOutput()},
+	}
+
+	srv, err := New(nil, postsFS, cfg)
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+
+	if srv.generator.Logger.Logger != injected {
+		t.Error("expected server to propagate its logger into the internal generator")
+	}
+}

--- a/pkg/server/logger_test.go
+++ b/pkg/server/logger_test.go
@@ -42,7 +42,7 @@ func TestServer_LoggerPropagatedToGenerator(t *testing.T) {
 	postsFS := makeInternalTestFS(t)
 	cfg := config.ServerConfig{
 		Server: []config.BaseServerOption{
-			{BaseOption: config.WithLogger(injected)},
+			config.WithLogger(injected).AsServerOption(),
 		},
 		Gen: []config.GeneratorOption{config.WithRawOutput()},
 	}

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -523,7 +523,7 @@ func TestServer_WithLoggerOptionTakesPrecedence(t *testing.T) {
 	postsFS := createTestFS(t)
 	cfg := config.ServerConfig{
 		Server: []config.BaseServerOption{
-			{BaseOption: config.WithLogger(optionLogger)},
+			config.WithLogger(optionLogger).AsServerOption(),
 		},
 		Gen: []config.GeneratorOption{config.WithRawOutput()},
 	}

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -5,7 +5,9 @@
 package server_test
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net/http"
@@ -505,6 +507,56 @@ func TestHandler_StripsHTMLExtension(t *testing.T) {
 	srv.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
 		t.Errorf("GET /index.html via bare server: got %d, want 200", w.Code)
+	}
+}
+
+// TestServer_WithLoggerOptionTakesPrecedence verifies that config.WithLogger in
+// cfg.Server takes precedence over the deprecated positional logger argument.
+func TestServer_WithLoggerOptionTakesPrecedence(t *testing.T) {
+	t.Parallel()
+
+	var optionBuf bytes.Buffer
+	optionLogger := slog.New(slog.NewTextHandler(&optionBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	positionalLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	postsFS := createTestFS(t)
+	cfg := config.ServerConfig{
+		Server: []config.BaseServerOption{
+			{BaseOption: config.WithLogger(optionLogger)},
+		},
+		Gen: []config.GeneratorOption{config.WithRawOutput()},
+	}
+
+	srv, err := server.New(positionalLogger, postsFS, cfg)
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+
+	if srv.Logger.Logger != optionLogger {
+		t.Error("expected WithLogger option to take precedence over positional logger arg")
+	}
+}
+
+// TestServer_PositionalLoggerFallback verifies that the positional logger is
+// used when no WithLogger option is provided (deprecated path still works).
+func TestServer_PositionalLoggerFallback(t *testing.T) {
+	t.Parallel()
+
+	positionalLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	postsFS := createTestFS(t)
+	cfg := config.ServerConfig{
+		Gen: []config.GeneratorOption{config.WithRawOutput()},
+	}
+
+	srv, err := server.New(positionalLogger, postsFS, cfg)
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+
+	if srv.Logger.Logger != positionalLogger {
+		t.Error("expected positional logger to be used when no WithLogger option is provided")
 	}
 }
 

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -454,10 +454,10 @@ func TestServer_StripsHTMLExtension_BlogRoot(t *testing.T) {
 	cfg := config.ServerConfig{
 		Server: []config.BaseServerOption{
 			config.WithPort(8080),
-			config.BaseServerOption{BaseOption: config.WithBlogRoot("/blog/")},
+			config.WithBlogRoot("/blog/").AsServerOption(),
 		},
 		Gen: []config.GeneratorOption{
-			config.WithBaseOption(config.WithBlogRoot("/blog/")),
+			config.WithBlogRoot("/blog/").AsGeneratorOption(),
 		},
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -113,7 +113,7 @@ func New(logger *slog.Logger, posts fs.FS, opts config.ServerConfig) (*Server, e
 	}
 
 	// Propagate the server's resolved logger into the generator.
-	genOpts := append(opts.Gen, config.WithBaseOption(config.WithLogger(srv.Logger.Logger)))
+	genOpts := append(opts.Gen, config.WithBaseOption(srv.Logger.AsOption()))
 	gen := generator.New(posts, renderer, genOpts...)
 	srv.generator = gen
 
@@ -242,7 +242,7 @@ func (s *Server) refreshHandler(ctx context.Context) error {
 
 	s.Logger.Logger.DebugContext(ctx, "Creating New Handler for Server")
 
-	handler := Handler(blog, nil, s.BlogRoot.AsOption(), config.WithLogger(s.Logger.Logger))
+	handler := Handler(blog, nil, s.BlogRoot.AsOption(), s.Logger.AsOption())
 
 	// Apply middleware stack if configured
 	if len(s.middleware) > 0 {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -36,13 +36,13 @@ import (
 //
 // All methods are safe for concurrent use by multiple goroutines.
 type Server struct {
-	logger   *slog.Logger
 	mu       sync.RWMutex // protects postsDir and generator during refreshHandler
 	postsDir fs.FS
 
 	config.BlogRoot
 	config.Port
 	config.Host
+	config.Logger
 
 	handler    atomic.Value            // stores http.Handler
 	middleware []middleware.Middleware // middleware chain
@@ -51,7 +51,6 @@ type Server struct {
 
 // New creates a new Server instance with the specified configuration.
 //
-// The logger is used for structured logging throughout the server lifecycle.
 // The posts filesystem contains the markdown blog posts to be served.
 // The opts parameter configures server behavior via the functional options pattern.
 //
@@ -60,28 +59,20 @@ type Server struct {
 //
 // Returns an error if template rendering or initial blog generation fails.
 // The server is ready to serve requests immediately upon successful return.
+//
+// # Logger
+//
+// Supply a logger via [config.WithLogger] in cfg.Server:
+//
+//	cfg.Server = append(cfg.Server, config.BaseServerOption{BaseOption: config.WithLogger(myLogger)})
+//
+// Deprecated: the positional logger parameter will be removed in v3.0.0.
+// Pass nil and supply the logger via config.WithLogger in cfg.Server instead.
+// When both are provided, the config.WithLogger option takes precedence.
 func New(logger *slog.Logger, posts fs.FS, opts config.ServerConfig) (*Server, error) {
-	var templatesDir fs.FS
-	if opts.TemplateDir != nil {
-		logger.Debug("Using custom templates")
-		templatesDir = opts.TemplateDir
-	} else {
-		logger.Debug("Using default templates")
-		templatesDir = templates.Default
-	}
-
-	renderer, err := generator.NewTemplateRenderer(templatesDir, opts.RendererOpts...)
-	if err != nil {
-		return nil, err
-	}
-
-	gen := generator.New(posts, renderer, opts.Gen...)
-
 	srv := &Server{
-		logger:    logger,
-		postsDir:  posts,
-		Port:      8080,
-		generator: gen,
+		postsDir: posts,
+		Port:     8080,
 	}
 
 	for _, opt := range opts.Server {
@@ -93,8 +84,38 @@ func New(logger *slog.Logger, posts fs.FS, opts config.ServerConfig) (*Server, e
 			opt.WithBlogRootFunc(&srv.BlogRoot)
 		} else if opt.WithMiddlewareFunc != nil {
 			opt.WithMiddlewareFunc(&srv.middleware)
+		} else if opt.WithLoggerFunc != nil {
+			opt.WithLoggerFunc(&srv.Logger)
 		}
 	}
+
+	// Precedence: WithLogger option > positional logger arg > slog.Default().
+	if srv.Logger.Logger == nil {
+		if logger != nil {
+			srv.Logger.Logger = logger
+		} else {
+			srv.Logger.Logger = slog.Default()
+		}
+	}
+
+	var templatesDir fs.FS
+	if opts.TemplateDir != nil {
+		srv.Logger.Logger.Debug("Using custom templates")
+		templatesDir = opts.TemplateDir
+	} else {
+		srv.Logger.Logger.Debug("Using default templates")
+		templatesDir = templates.Default
+	}
+
+	renderer, err := generator.NewTemplateRenderer(templatesDir, opts.RendererOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Propagate the server's resolved logger into the generator.
+	genOpts := append(opts.Gen, config.WithBaseOption(config.WithLogger(srv.Logger.Logger)))
+	gen := generator.New(posts, renderer, genOpts...)
+	srv.generator = gen
 
 	// Sync the resolved BlogRoot to the generator so rendered links use the correct prefix.
 	gen.BlogRoot = srv.BlogRoot
@@ -104,7 +125,7 @@ func New(logger *slog.Logger, posts fs.FS, opts config.ServerConfig) (*Server, e
 		return nil, fmt.Errorf("failed to initialize handler: %w", err)
 	}
 
-	logger.Debug("Server created successfully")
+	srv.Logger.Logger.Debug("Server created successfully")
 	return srv, nil
 }
 
@@ -120,7 +141,7 @@ func New(logger *slog.Logger, posts fs.FS, opts config.ServerConfig) (*Server, e
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h := s.handler.Load()
 	if h == nil {
-		s.logger.ErrorContext(r.Context(), "handler not initialized")
+		s.Logger.Logger.ErrorContext(r.Context(), "handler not initialized")
 		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
 		return
 	}
@@ -154,7 +175,7 @@ func (s *Server) Run(ctx context.Context) error {
 	// shutdown goroutine wakes and wg.Wait() can return.
 	var listenErr error
 	wg.Go(func() {
-		s.logger.Info(
+		s.Logger.Logger.Info(
 			"server listening",
 			slog.String("address", httpServer.Addr),
 		)
@@ -211,7 +232,7 @@ func (s *Server) UpdatePosts(posts fs.FS, ctx context.Context) error {
 // Returns an error if blog generation fails. In case of error, the previous
 // handler remains active and continues serving requests.
 func (s *Server) refreshHandler(ctx context.Context) error {
-	s.logger.DebugContext(ctx, "Refreshing HTTP Handler")
+	s.Logger.Logger.DebugContext(ctx, "Refreshing HTTP Handler")
 	s.generator.DebugConfig(ctx)
 
 	blog, err := s.generator.Generate(ctx)
@@ -219,9 +240,9 @@ func (s *Server) refreshHandler(ctx context.Context) error {
 		return fmt.Errorf("failed to generate blog: %w", err)
 	}
 
-	s.logger.DebugContext(ctx, "Creating New Handler for Server")
+	s.Logger.Logger.DebugContext(ctx, "Creating New Handler for Server")
 
-	handler := Handler(blog, s.logger, s.BlogRoot.AsOption())
+	handler := Handler(blog, nil, s.BlogRoot.AsOption(), config.WithLogger(s.Logger.Logger))
 
 	// Apply middleware stack if configured
 	if len(s.middleware) > 0 {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -113,7 +113,9 @@ func New(logger *slog.Logger, posts fs.FS, opts config.ServerConfig) (*Server, e
 	}
 
 	// Propagate the server's resolved logger into the generator.
-	genOpts := append(opts.Gen, srv.Logger.AsOption().AsGeneratorOption())
+	genOpts := make([]config.GeneratorOption, 0, len(opts.Gen)+1)
+	genOpts = append(genOpts, opts.Gen...)
+	genOpts = append(genOpts, srv.Logger.AsOption().AsGeneratorOption())
 	gen := generator.New(posts, renderer, genOpts...)
 	srv.generator = gen
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -64,7 +64,7 @@ type Server struct {
 //
 // Supply a logger via [config.WithLogger] in cfg.Server:
 //
-//	cfg.Server = append(cfg.Server, config.BaseServerOption{BaseOption: config.WithLogger(myLogger)})
+//	cfg.Server = append(cfg.Server, config.WithLogger(myLogger).AsServerOption())
 //
 // Deprecated: the positional logger parameter will be removed in v3.0.0.
 // Pass nil and supply the logger via config.WithLogger in cfg.Server instead.
@@ -113,7 +113,7 @@ func New(logger *slog.Logger, posts fs.FS, opts config.ServerConfig) (*Server, e
 	}
 
 	// Propagate the server's resolved logger into the generator.
-	genOpts := append(opts.Gen, config.WithBaseOption(srv.Logger.AsOption()))
+	genOpts := append(opts.Gen, srv.Logger.AsOption().AsGeneratorOption())
 	gen := generator.New(posts, renderer, genOpts...)
 	srv.generator = gen
 

--- a/pkg/watcher/doc.go
+++ b/pkg/watcher/doc.go
@@ -29,7 +29,7 @@
 //	postsPath := "posts/"
 //	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 //
-//	w, err := watcher.New(postsPath, config.WithBaseWatcherOption(config.WithLogger(logger)))
+//	w, err := watcher.New(postsPath, config.WithLogger(logger).AsWatcherOption())
 //	if err != nil {
 //	    log.Fatal(err)
 //	}

--- a/pkg/watcher/doc.go
+++ b/pkg/watcher/doc.go
@@ -21,13 +21,15 @@
 //	    "log/slog"
 //	    "os"
 //
+//	    "github.com/harrydayexe/GoBlog/v2/pkg/config"
 //	    "github.com/harrydayexe/GoBlog/v2/pkg/server"
 //	    "github.com/harrydayexe/GoBlog/v2/pkg/watcher"
 //	)
 //
 //	postsPath := "posts/"
+//	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 //
-//	w, err := watcher.New(postsPath)
+//	w, err := watcher.New(postsPath, config.WithBaseWatcherOption(config.WithLogger(logger)))
 //	if err != nil {
 //	    log.Fatal(err)
 //	}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -121,9 +121,9 @@ func (w *Watcher) Run(ctx context.Context, onChange func(context.Context)) error
 			if event.Has(fsnotify.Remove) {
 				if slicesContains(w.fw.WatchList(), event.Name) {
 					if err := w.fw.Remove(event.Name); err != nil {
-						logger.DebugContext(ctx, "watcher: failed to remove watch for deleted directory", slog.String("path", event.Name), slog.Any("error", err))
+						w.Logger.Logger.DebugContext(ctx, "watcher: failed to remove watch for deleted directory", slog.String("path", event.Name), slog.Any("error", err))
 					} else {
-						logger.DebugContext(ctx, "watcher: released watch for deleted directory", slog.String("path", event.Name))
+						w.Logger.Logger.DebugContext(ctx, "watcher: released watch for deleted directory", slog.String("path", event.Name))
 					}
 					continue
 				}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -24,6 +24,7 @@ type Watcher struct {
 	path string
 
 	config.WatcherDebounce
+	config.Logger
 
 	fw *fsnotify.Watcher
 }
@@ -54,7 +55,13 @@ func New(path string, opts ...config.WatcherOption) (*Watcher, error) {
 	for _, opt := range opts {
 		if opt.WithDebounceFunc != nil {
 			opt.WithDebounceFunc(&w.WatcherDebounce)
+		} else if opt.WithLoggerFunc != nil {
+			opt.WithLoggerFunc(&w.Logger)
 		}
+	}
+
+	if w.Logger.Logger == nil {
+		w.Logger.Logger = slog.Default()
 	}
 
 	if err := w.addDirs(path); err != nil {
@@ -75,8 +82,6 @@ func New(path string, opts ...config.WatcherOption) (*Watcher, error) {
 func (w *Watcher) Run(ctx context.Context, onChange func(context.Context)) error {
 	defer w.fw.Close()
 
-	logger := slog.Default()
-
 	timer := time.NewTimer(0)
 	<-timer.C // drain so it doesn't fire immediately
 
@@ -93,7 +98,7 @@ func (w *Watcher) Run(ctx context.Context, onChange func(context.Context)) error
 			if isNoise(event.Name) {
 				continue
 			}
-			logger.DebugContext(ctx, "file event", slog.String("path", event.Name), slog.String("op", event.Op.String()))
+			w.Logger.Logger.DebugContext(ctx, "file event", slog.String("path", event.Name), slog.String("op", event.Op.String()))
 
 			// If a new directory appeared, watch it — then skip the
 			// debounce reset since a bare directory create is not a
@@ -101,9 +106,9 @@ func (w *Watcher) Run(ctx context.Context, onChange func(context.Context)) error
 			if event.Has(fsnotify.Create) {
 				if fi, err := os.Stat(event.Name); err == nil && fi.IsDir() {
 					if err := w.fw.Add(event.Name); err != nil {
-						logger.WarnContext(ctx, "watcher: failed to add new directory", slog.String("path", event.Name), slog.Any("error", err))
+						w.Logger.Logger.WarnContext(ctx, "watcher: failed to add new directory", slog.String("path", event.Name), slog.Any("error", err))
 					} else {
-						logger.DebugContext(ctx, "watcher: watching new directory", slog.String("path", event.Name))
+						w.Logger.Logger.DebugContext(ctx, "watcher: watching new directory", slog.String("path", event.Name))
 					}
 					continue
 				}
@@ -122,10 +127,10 @@ func (w *Watcher) Run(ctx context.Context, onChange func(context.Context)) error
 			if !ok {
 				return nil
 			}
-			logger.WarnContext(ctx, "watcher: fsnotify error", slog.Any("error", err))
+			w.Logger.Logger.WarnContext(ctx, "watcher: fsnotify error", slog.Any("error", err))
 
 		case <-timer.C:
-			logger.InfoContext(ctx, "watcher: posts changed, regenerating")
+			w.Logger.Logger.InfoContext(ctx, "watcher: posts changed, regenerating")
 			childCtx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			onChange(childCtx)
@@ -155,7 +160,7 @@ func (w *Watcher) addDirs(path string) error {
 		if err := w.fw.Add(p); err != nil {
 			return fmt.Errorf("watcher: failed to watch directory %q: %w", p, err)
 		}
-		slog.Default().Debug("watcher: watching directory", slog.String("path", p))
+		w.Logger.Logger.Debug("watcher: watching directory", slog.String("path", p))
 		return nil
 	})
 }

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/harrydayexe/GoBlog/v2/pkg/watcher"
 )
 
-// TestNew_WithLogger verifies that a logger injected via config.WithBaseWatcherOption
-// + config.WithLogger is stored on the Watcher.
+// TestNew_WithLogger verifies that a logger injected via config.WithLogger
+// is stored on the Watcher.
 func TestNew_WithLogger(t *testing.T) {
 	t.Parallel()
 
@@ -27,7 +27,7 @@ func TestNew_WithLogger(t *testing.T) {
 	var buf bytes.Buffer
 	injected := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	w, err := watcher.New(dir, config.WithBaseWatcherOption(config.WithLogger(injected)))
+	w, err := watcher.New(dir, config.WithLogger(injected).AsWatcherOption())
 	if err != nil {
 		t.Fatalf("New() failed: %v", err)
 	}

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -5,7 +5,9 @@
 package watcher_test
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -15,6 +17,25 @@ import (
 	"github.com/harrydayexe/GoBlog/v2/pkg/config"
 	"github.com/harrydayexe/GoBlog/v2/pkg/watcher"
 )
+
+// TestNew_WithLogger verifies that a logger injected via config.WithBaseWatcherOption
+// + config.WithLogger is stored on the Watcher.
+func TestNew_WithLogger(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	var buf bytes.Buffer
+	injected := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	w, err := watcher.New(dir, config.WithBaseWatcherOption(config.WithLogger(injected)))
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if w.Logger.Logger != injected {
+		t.Error("WithLogger option was not applied: watcher logger does not match injected logger")
+	}
+}
 
 const shortDebounce = 50 * time.Millisecond
 


### PR DESCRIPTION
Standardise structured logging across all library packages on the functional-options pattern used throughout the rest of the codebase.

Previously pkg/server took a positional *slog.Logger while pkg/generator, pkg/watcher, pkg/outputter, and pkg/parser resolved slog.Default() internally with no caller injection.

Changes:
- Add config.Logger named type and WithLogger(*slog.Logger) BaseOption
- WatcherOption now embeds BaseOption (consistent with BaseServerOption and GeneratorOption); WithBaseWatcherOption helper added
- All consumer structs (Generator, Server, HandlerConfig, Watcher, DirectoryWriter, Parser) embed config.Logger; default to slog.Default() when no logger option is supplied
- parser.WithLogger added to the parser's own option system; Generator propagates its resolved logger into the parser it creates internally
- server.New and server.Handler keep their positional *slog.Logger parameter but mark it deprecated (v3.0.0 will remove it); WithLogger option takes precedence over the positional arg
- Server propagates its resolved logger into the internal generator and handler it constructs
- CLI (internal/server) migrated to the new pattern: passes nil for the deprecated positional arg and supplies config.WithLogger via cfg.Server
- Documentation updated across all affected packages and README
- Injection tests added to all packages; internal test for generator propagation via pkg/server/logger_test.go

Phase 2 (removing the positional logger entirely) tracked in issue #55.

Closes #52
<!--- START AUTOGENERATED NOTES --->
### Changelog ([#56](https://github.com/harrydayexe/GoBlog/pull/56))

#### ✨ New Features
- (logging) unify logger injection via config.WithLogger (#52)
- (config) add Logger.AsOption and document Option interface
- (config) add As*Option methods and deprecate WithBaseOption

#### 🐛 Bug Fixes
- (watcher) use embedded logger in Remove event handler
- (server) avoid mutating caller's slice backing array in New

#### 📚 Documentation
- update logger injection examples to use As*Option methods
- fix small error in example

#### ❓ Uncategorised!
- Merge branch 'main' into logging-review

<!--- END AUTOGENERATED NOTES --->