### PR TITLE
feat(models): add optional lastEdited timestamp to Post

### DIFF
--- a/pkg/models/examples_test.go
+++ b/pkg/models/examples_test.go
@@ -113,6 +113,24 @@ func ExamplePost_ShortDate() {
 	// Output: 2024-03-05
 }
 
+func ExamplePost_FormattedLastEdited() {
+	post := &models.Post{
+		LastEdited: time.Date(2024, 12, 25, 10, 30, 0, 0, time.UTC),
+	}
+
+	fmt.Println(post.FormattedLastEdited())
+	// Output: December 25, 2024
+}
+
+func ExamplePost_ShortLastEdited() {
+	post := &models.Post{
+		LastEdited: time.Date(2024, 3, 5, 10, 30, 0, 0, time.UTC),
+	}
+
+	fmt.Println(post.ShortLastEdited())
+	// Output: 2024-03-05
+}
+
 func ExamplePostList_FilterByTag() {
 	posts := models.PostList{
 		{Title: "Go Basics", Tags: []string{"go", "tutorial"}},

--- a/pkg/models/post.go
+++ b/pkg/models/post.go
@@ -23,6 +23,10 @@ type Post struct {
 	// Author is the name of the post's author. It is optional; when not declared
 	// in the front matter it defaults to an empty string.
 	Author string `yaml:"author"`
+	// LastEdited is the date the post was last edited after publication. It is
+	// optional; when not declared in the front matter it remains the zero time
+	// and the default templates omit any "edited on" line.
+	LastEdited time.Time `yaml:"lastEdited"`
 
 	// Generated fields
 	Slug               string        // URL-friendly identifier
@@ -30,7 +34,6 @@ type Post struct {
 	HTMLContent        template.HTML // HTML content for templates (not escaped)
 	RawContent         string        // Original markdown content
 	SourcePath         string        // Path to source markdown file
-	PublishDate        time.Time     // Formatted publish date
 	BlogRoot           string        // Blog root path for URLs (e.g., "/" or "/blog/")
 	ReadingTimeMinutes int           // Estimated reading time in minutes (0 = disabled)
 }
@@ -53,6 +56,11 @@ func (p *Post) Validate() error {
 
 	if p.Description == "" {
 		return fmt.Errorf("post missing required field: description (source: %s)", p.SourcePath)
+	}
+
+	if !p.LastEdited.IsZero() && p.LastEdited.Before(p.Date) {
+		return fmt.Errorf("post has lastEdited (%s) before date (%s) (source: %s)",
+			p.LastEdited.Format("2006-01-02"), p.Date.Format("2006-01-02"), p.SourcePath)
 	}
 
 	return nil
@@ -141,6 +149,27 @@ func (p *Post) FormattedDate() string {
 // (e.g., "2024-03-15").
 func (p *Post) ShortDate() string {
 	return p.Date.Format("2006-01-02")
+}
+
+// HasLastEdited reports whether the post has a last-edited date set.
+// Returns false when LastEdited is the zero time (i.e. the front matter did
+// not include a lastEdited key).
+func (p *Post) HasLastEdited() bool {
+	return !p.LastEdited.IsZero()
+}
+
+// FormattedLastEdited returns the last-edited date in a human-readable format.
+// The format used is "January 2, 2006" (e.g., "March 15, 2024").
+// Call HasLastEdited first to confirm the date is set.
+func (p *Post) FormattedLastEdited() string {
+	return p.LastEdited.Format("January 2, 2006")
+}
+
+// ShortLastEdited returns the last-edited date in YYYY-MM-DD format.
+// This format is suitable for ISO 8601 compatibility and sorting
+// (e.g., "2024-03-15"). Call HasLastEdited first to confirm the date is set.
+func (p *Post) ShortLastEdited() string {
+	return p.LastEdited.Format("2006-01-02")
 }
 
 // PostList is a collection of posts with helper methods

--- a/pkg/models/post_test.go
+++ b/pkg/models/post_test.go
@@ -73,6 +73,37 @@ func TestPost_Validate(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		{
+			name: "zero lastEdited is valid",
+			post: Post{
+				Title:       "Test Post",
+				Date:        now,
+				Description: "A test post",
+			},
+			expectErr: false,
+		},
+		{
+			name: "lastEdited after date is valid",
+			post: Post{
+				Title:       "Test Post",
+				Date:        now,
+				Description: "A test post",
+				LastEdited:  now.Add(24 * time.Hour),
+			},
+			expectErr: false,
+		},
+		{
+			name: "lastEdited before date is invalid",
+			post: Post{
+				Title:       "Test Post",
+				Date:        now,
+				Description: "A test post",
+				LastEdited:  now.Add(-24 * time.Hour),
+				SourcePath:  "test.md",
+			},
+			expectErr: true,
+			errText:   "lastEdited",
+		},
 	}
 
 	for _, tt := range tests {
@@ -278,6 +309,51 @@ func TestPost_ShortDate(t *testing.T) {
 	expected := "2024-03-15"
 	if got := post.ShortDate(); got != expected {
 		t.Errorf("ShortDate() = %q, want %q", got, expected)
+	}
+}
+
+// TestPost_HasLastEdited tests the HasLastEdited helper
+func TestPost_HasLastEdited(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero LastEdited returns false", func(t *testing.T) {
+		t.Parallel()
+		post := Post{}
+		if post.HasLastEdited() {
+			t.Error("expected HasLastEdited() = false for zero time")
+		}
+	})
+
+	t.Run("non-zero LastEdited returns true", func(t *testing.T) {
+		t.Parallel()
+		post := Post{LastEdited: time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)}
+		if !post.HasLastEdited() {
+			t.Error("expected HasLastEdited() = true for non-zero time")
+		}
+	})
+}
+
+// TestPost_FormattedLastEdited tests last-edited date formatting
+func TestPost_FormattedLastEdited(t *testing.T) {
+	t.Parallel()
+	date := time.Date(2024, 3, 15, 10, 30, 0, 0, time.UTC)
+	post := Post{LastEdited: date}
+
+	expected := "March 15, 2024"
+	if got := post.FormattedLastEdited(); got != expected {
+		t.Errorf("FormattedLastEdited() = %q, want %q", got, expected)
+	}
+}
+
+// TestPost_ShortLastEdited tests short last-edited date formatting
+func TestPost_ShortLastEdited(t *testing.T) {
+	t.Parallel()
+	date := time.Date(2024, 3, 15, 10, 30, 0, 0, time.UTC)
+	post := Post{LastEdited: date}
+
+	expected := "2024-03-15"
+	if got := post.ShortLastEdited(); got != expected {
+		t.Errorf("ShortLastEdited() = %q, want %q", got, expected)
 	}
 }
 

--- a/pkg/parser/examples_test.go
+++ b/pkg/parser/examples_test.go
@@ -88,7 +88,7 @@ func ExampleParser_ParseDirectory() {
 
 	fmt.Printf("Valid posts: %d\n", len(posts))
 	// Output: Parsed with some errors
-	// Valid posts: 4
+	// Valid posts: 5
 	// Errors: 4
 }
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestNew_WithLogger verifies that a logger injected via parser.WithLogger
@@ -473,5 +474,36 @@ func TestNew_CombinedOptions(t *testing.T) {
 
 	if !strings.Contains(string(post.Content), "<sup") {
 		t.Error("expected footnotes to still work when code highlighting is disabled")
+	}
+}
+
+func TestParseFile_WithLastEdited(t *testing.T) {
+	t.Parallel()
+	p := New()
+	fsys := os.DirFS("testdata")
+
+	post, err := p.ParseFile(context.Background(), fsys, "with-last-edited.md")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	expected := time.Date(2026, 2, 15, 10, 0, 0, 0, time.UTC)
+	if !post.LastEdited.Equal(expected) {
+		t.Errorf("expected LastEdited %v, got %v", expected, post.LastEdited)
+	}
+}
+
+func TestParseFile_NoLastEdited(t *testing.T) {
+	t.Parallel()
+	p := New()
+	fsys := os.DirFS("testdata")
+
+	post, err := p.ParseFile(context.Background(), fsys, "no-author.md")
+	if err != nil {
+		t.Fatalf("expected no error for post without lastEdited, got: %v", err)
+	}
+
+	if !post.LastEdited.IsZero() {
+		t.Errorf("expected LastEdited to be zero time, got %v", post.LastEdited)
 	}
 }

--- a/pkg/parser/testdata/with-last-edited.md
+++ b/pkg/parser/testdata/with-last-edited.md
@@ -1,0 +1,12 @@
+---
+title: "A Post With Last Edited Date"
+date: 2026-01-10T10:00:00Z
+lastEdited: 2026-02-15T10:00:00Z
+description: "This post has a lastEdited date set in the front matter"
+tags: [go, testing]
+author: "Jane Doe"
+---
+
+# Updated Post
+
+This post has been edited after its original publication date.

--- a/pkg/templates/default/pages/post.tmpl
+++ b/pkg/templates/default/pages/post.tmpl
@@ -12,6 +12,11 @@
                 <time datetime="{{.Post.Date.Format "2006-01-02"}}" class="text-sm text-gray-500">
                     {{.Post.FormattedDate}}{{if .Post.ReadingTimeMinutes}} · {{.Post.ReadingTimeMinutes}} min read{{end}}
                 </time>
+                {{if .Post.HasLastEdited}}
+                <time datetime="{{.Post.ShortLastEdited}}" class="block text-sm text-gray-500 italic">
+                    Edited on {{.Post.FormattedLastEdited}}
+                </time>
+                {{end}}
 
                 <!-- Title -->
                 <h1 class="mt-2 text-4xl font-bold text-gray-900 leading-tight">


### PR DESCRIPTION
Add a LastEdited time.Time field (yaml:"lastEdited") to Post so bloggers can record when a post was edited after its original publication date. Validate() rejects a lastEdited value that pre-dates the publish date. Three helpers — HasLastEdited, FormattedLastEdited, ShortLastEdited — mirror the existing FormattedDate/ShortDate pattern for clean template use. The default post page template conditionally renders an "Edited on" <time> element when the field is set. The dead PublishDate field is also removed.

Closes #61
<!--- START AUTOGENERATED NOTES --->
### Changelog ([#64](https://github.com/harrydayexe/GoBlog/pull/64))

#### ✨ New Features
- (models) add optional lastEdited timestamp to Post

<!--- END AUTOGENERATED NOTES --->