### PR TITLE
draft: remove deprecated positional logger from New and Handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ cfg := config.ServerConfig{
         config.WithLogger(logger).AsServerOption(),
     },
 }
-srv, err := server.New(nil, postsFS, cfg)
+srv, err := server.New(postsFS, cfg)
 
 // Watcher
 w, err := watcher.New("posts/", config.WithLogger(logger).AsWatcherOption())

--- a/internal/server/command_test.go
+++ b/internal/server/command_test.go
@@ -6,8 +6,6 @@ package server
 
 import (
 	"context"
-	"io"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -41,10 +39,6 @@ func testFS() fstest.MapFS {
 	}
 }
 
-func discardLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
-}
-
 // TestRunServe_CanceledContext verifies that runServe returns nil when the context is canceled.
 func TestRunServe_CanceledContext(t *testing.T) {
 	t.Parallel()
@@ -70,7 +64,7 @@ func TestRunServe_ServesIndex(t *testing.T) {
 		Server: []config.BaseServerOption{config.WithPort(0)},
 	}
 
-	srv, err := pkgserver.New(discardLogger(), testFS(), cfg)
+	srv, err := pkgserver.New(testFS(), cfg)
 	if err != nil {
 		t.Fatalf("server.New() error = %v", err)
 	}
@@ -92,7 +86,7 @@ func TestRunServe_ServesPost(t *testing.T) {
 		Server: []config.BaseServerOption{config.WithPort(0)},
 	}
 
-	srv, err := pkgserver.New(discardLogger(), testFS(), cfg)
+	srv, err := pkgserver.New(testFS(), cfg)
 	if err != nil {
 		t.Fatalf("server.New() error = %v", err)
 	}
@@ -117,7 +111,7 @@ func TestRunServe_BlogRoot(t *testing.T) {
 		},
 	}
 
-	srv, err := pkgserver.New(discardLogger(), testFS(), cfg)
+	srv, err := pkgserver.New(testFS(), cfg)
 	if err != nil {
 		t.Fatalf("server.New() error = %v", err)
 	}
@@ -173,7 +167,7 @@ func TestRunServe_WatchReloadsPost(t *testing.T) {
 		Server: []config.BaseServerOption{config.WithPort(0)},
 	}
 
-	srv, err := pkgserver.New(discardLogger(), os.DirFS(dir), cfg)
+	srv, err := pkgserver.New(os.DirFS(dir), cfg)
 	if err != nil {
 		t.Fatalf("server.New() error = %v", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -84,7 +84,7 @@ func NewServeCommand(ctx context.Context, c *cli.Command) error {
 }
 
 func runServe(ctx context.Context, postsPath string, posts fs.FS, cfg config.ServerConfig, watch bool) error {
-	srv, err := server.New(nil, posts, cfg)
+	srv, err := server.New(posts, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/doc.go
+++ b/pkg/server/doc.go
@@ -32,7 +32,7 @@
 //	    },
 //	}
 //
-//	srv, err := server.New(nil, postsFS, cfg)
+//	srv, err := server.New(postsFS, cfg)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
@@ -76,7 +76,7 @@
 //	    },
 //	}
 //
-//	srv, err := server.New(nil, postsFS, cfg)
+//	srv, err := server.New(postsFS, cfg)
 //
 // Custom middleware can be added following the standard pattern:
 //

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -47,12 +47,8 @@ type HandlerConfig struct {
 //
 // Supply a logger via [config.WithLogger] in opts:
 //
-//	h := server.Handler(blog, nil, config.WithLogger(myLogger), config.WithBlogRoot("/blog/"))
-//
-// Deprecated: the positional logger parameter will be removed in v3.0.0.
-// Pass nil and supply the logger via config.WithLogger in opts instead.
-// When both are provided, the config.WithLogger option takes precedence.
-func Handler(blog *generator.GeneratedBlog, logger *slog.Logger, opts ...config.BaseOption) http.Handler {
+//	h := server.Handler(blog, config.WithLogger(myLogger), config.WithBlogRoot("/blog/"))
+func Handler(blog *generator.GeneratedBlog, opts ...config.BaseOption) http.Handler {
 	cfg := HandlerConfig{
 		BlogRoot: config.BlogRoot("/"),
 	}
@@ -65,13 +61,8 @@ func Handler(blog *generator.GeneratedBlog, logger *slog.Logger, opts ...config.
 		}
 	}
 
-	// Precedence: WithLogger option > positional logger arg > slog.Default().
 	if cfg.Logger.Logger == nil {
-		if logger != nil {
-			cfg.Logger.Logger = logger
-		} else {
-			cfg.Logger.Logger = slog.Default()
-		}
+		cfg.Logger.Logger = slog.Default()
 	}
 
 	trimmed := strings.Trim(string(cfg.BlogRoot), "/")

--- a/pkg/server/logger_test.go
+++ b/pkg/server/logger_test.go
@@ -47,7 +47,7 @@ func TestServer_LoggerPropagatedToGenerator(t *testing.T) {
 		Gen: []config.GeneratorOption{config.WithRawOutput()},
 	}
 
-	srv, err := New(nil, postsFS, cfg)
+	srv, err := New(postsFS, cfg)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -5,9 +5,7 @@
 package server_test
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"io/fs"
 	"log/slog"
 	"net/http"
@@ -24,7 +22,6 @@ import (
 // TestServerWithoutMiddleware verifies that servers without middleware work correctly
 // (backward compatibility).
 func TestServerWithoutMiddleware(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	postsFS := createTestFS(t)
 
 	cfg := config.ServerConfig{
@@ -36,7 +33,7 @@ func TestServerWithoutMiddleware(t *testing.T) {
 		},
 	}
 
-	srv, err := server.New(logger, postsFS, cfg)
+	srv, err := server.New(postsFS, cfg)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}
@@ -53,7 +50,6 @@ func TestServerWithoutMiddleware(t *testing.T) {
 
 // TestServerWithSingleMiddleware tests that a single middleware is correctly applied.
 func TestServerWithSingleMiddleware(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	postsFS := createTestFS(t)
 
 	// Track if middleware was called
@@ -76,7 +72,7 @@ func TestServerWithSingleMiddleware(t *testing.T) {
 		},
 	}
 
-	srv, err := server.New(logger, postsFS, cfg)
+	srv, err := server.New(postsFS, cfg)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}
@@ -97,7 +93,6 @@ func TestServerWithSingleMiddleware(t *testing.T) {
 
 // TestServerWithMultipleMiddleware tests that multiple middleware are chained correctly.
 func TestServerWithMultipleMiddleware(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	postsFS := createTestFS(t)
 
 	// Track middleware execution
@@ -131,7 +126,7 @@ func TestServerWithMultipleMiddleware(t *testing.T) {
 		},
 	}
 
-	srv, err := server.New(logger, postsFS, cfg)
+	srv, err := server.New(postsFS, cfg)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}
@@ -172,7 +167,6 @@ func TestServerWithMultipleMiddleware(t *testing.T) {
 // TestMiddlewarePersistsAcrossUpdates verifies that middleware continues to work
 // after UpdatePosts() is called.
 func TestMiddlewarePersistsAcrossUpdates(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	postsFS := createTestFS(t)
 
 	var callCount int
@@ -193,7 +187,7 @@ func TestMiddlewarePersistsAcrossUpdates(t *testing.T) {
 		},
 	}
 
-	srv, err := server.New(logger, postsFS, cfg)
+	srv, err := server.New(postsFS, cfg)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}
@@ -226,7 +220,6 @@ func TestMiddlewarePersistsAcrossUpdates(t *testing.T) {
 // TestMultipleWithMiddlewareCalls tests that multiple WithMiddleware calls
 // correctly append to the middleware chain.
 func TestMultipleWithMiddlewareCalls(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	postsFS := createTestFS(t)
 
 	firstMiddleware := func(h http.Handler) http.Handler {
@@ -254,7 +247,7 @@ func TestMultipleWithMiddlewareCalls(t *testing.T) {
 		},
 	}
 
-	srv, err := server.New(logger, postsFS, cfg)
+	srv, err := server.New(postsFS, cfg)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}
@@ -297,7 +290,7 @@ func ExampleServer_withMiddleware() {
 		},
 	}
 
-	srv, err := server.New(logger, postsFS, cfg)
+	srv, err := server.New(postsFS, cfg)
 	if err != nil {
 		logger.Error("failed to create server", "error", err)
 		return
@@ -312,7 +305,6 @@ func ExampleServer_withMiddleware() {
 func TestServerDisableTags(t *testing.T) {
 	t.Parallel()
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	postsFS := createTestFS(t)
 
 	cfg := config.ServerConfig{
@@ -324,7 +316,7 @@ func TestServerDisableTags(t *testing.T) {
 		},
 	}
 
-	srv, err := server.New(logger, postsFS, cfg)
+	srv, err := server.New(postsFS, cfg)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}
@@ -354,7 +346,6 @@ func TestServerDisableTags(t *testing.T) {
 func TestServerTagsEnabledByDefault(t *testing.T) {
 	t.Parallel()
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	postsFS := createTestFS(t)
 
 	cfg := config.ServerConfig{
@@ -363,7 +354,7 @@ func TestServerTagsEnabledByDefault(t *testing.T) {
 		},
 	}
 
-	srv, err := server.New(logger, postsFS, cfg)
+	srv, err := server.New(postsFS, cfg)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}
@@ -383,7 +374,6 @@ func TestServerTagsEnabledByDefault(t *testing.T) {
 func TestServer_StripsHTMLExtension(t *testing.T) {
 	t.Parallel()
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	postsFS := createTestFS(t)
 
 	cfg := config.ServerConfig{
@@ -392,7 +382,7 @@ func TestServer_StripsHTMLExtension(t *testing.T) {
 		},
 	}
 
-	srv, err := server.New(logger, postsFS, cfg)
+	srv, err := server.New(postsFS, cfg)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}
@@ -448,7 +438,6 @@ func TestServer_StripsHTMLExtension(t *testing.T) {
 func TestServer_StripsHTMLExtension_BlogRoot(t *testing.T) {
 	t.Parallel()
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	postsFS := createTestFS(t)
 
 	cfg := config.ServerConfig{
@@ -461,7 +450,7 @@ func TestServer_StripsHTMLExtension_BlogRoot(t *testing.T) {
 		},
 	}
 
-	srv, err := server.New(logger, postsFS, cfg)
+	srv, err := server.New(postsFS, cfg)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}
@@ -489,14 +478,13 @@ func TestServer_StripsHTMLExtension_BlogRoot(t *testing.T) {
 func TestHandler_StripsHTMLExtension(t *testing.T) {
 	t.Parallel()
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	postsFS := createTestFS(t)
 
 	// Build a GeneratedBlog manually via the generator.
 	cfg := config.ServerConfig{
 		Gen: []config.GeneratorOption{config.WithRawOutput()},
 	}
-	srv, err := server.New(logger, postsFS, cfg)
+	srv, err := server.New(postsFS, cfg)
 	if err != nil {
 		t.Fatalf("failed to create server: %v", err)
 	}
@@ -507,56 +495,6 @@ func TestHandler_StripsHTMLExtension(t *testing.T) {
 	srv.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
 		t.Errorf("GET /index.html via bare server: got %d, want 200", w.Code)
-	}
-}
-
-// TestServer_WithLoggerOptionTakesPrecedence verifies that config.WithLogger in
-// cfg.Server takes precedence over the deprecated positional logger argument.
-func TestServer_WithLoggerOptionTakesPrecedence(t *testing.T) {
-	t.Parallel()
-
-	var optionBuf bytes.Buffer
-	optionLogger := slog.New(slog.NewTextHandler(&optionBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-
-	positionalLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
-
-	postsFS := createTestFS(t)
-	cfg := config.ServerConfig{
-		Server: []config.BaseServerOption{
-			config.WithLogger(optionLogger).AsServerOption(),
-		},
-		Gen: []config.GeneratorOption{config.WithRawOutput()},
-	}
-
-	srv, err := server.New(positionalLogger, postsFS, cfg)
-	if err != nil {
-		t.Fatalf("failed to create server: %v", err)
-	}
-
-	if srv.Logger.Logger != optionLogger {
-		t.Error("expected WithLogger option to take precedence over positional logger arg")
-	}
-}
-
-// TestServer_PositionalLoggerFallback verifies that the positional logger is
-// used when no WithLogger option is provided (deprecated path still works).
-func TestServer_PositionalLoggerFallback(t *testing.T) {
-	t.Parallel()
-
-	positionalLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
-
-	postsFS := createTestFS(t)
-	cfg := config.ServerConfig{
-		Gen: []config.GeneratorOption{config.WithRawOutput()},
-	}
-
-	srv, err := server.New(positionalLogger, postsFS, cfg)
-	if err != nil {
-		t.Fatalf("failed to create server: %v", err)
-	}
-
-	if srv.Logger.Logger != positionalLogger {
-		t.Error("expected positional logger to be used when no WithLogger option is provided")
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -65,11 +65,7 @@ type Server struct {
 // Supply a logger via [config.WithLogger] in cfg.Server:
 //
 //	cfg.Server = append(cfg.Server, config.WithLogger(myLogger).AsServerOption())
-//
-// Deprecated: the positional logger parameter will be removed in v3.0.0.
-// Pass nil and supply the logger via config.WithLogger in cfg.Server instead.
-// When both are provided, the config.WithLogger option takes precedence.
-func New(logger *slog.Logger, posts fs.FS, opts config.ServerConfig) (*Server, error) {
+func New(posts fs.FS, opts config.ServerConfig) (*Server, error) {
 	srv := &Server{
 		postsDir: posts,
 		Port:     8080,
@@ -89,13 +85,8 @@ func New(logger *slog.Logger, posts fs.FS, opts config.ServerConfig) (*Server, e
 		}
 	}
 
-	// Precedence: WithLogger option > positional logger arg > slog.Default().
 	if srv.Logger.Logger == nil {
-		if logger != nil {
-			srv.Logger.Logger = logger
-		} else {
-			srv.Logger.Logger = slog.Default()
-		}
+		srv.Logger.Logger = slog.Default()
 	}
 
 	var templatesDir fs.FS
@@ -244,7 +235,7 @@ func (s *Server) refreshHandler(ctx context.Context) error {
 
 	s.Logger.Logger.DebugContext(ctx, "Creating New Handler for Server")
 
-	handler := Handler(blog, nil, s.BlogRoot.AsOption(), s.Logger.AsOption())
+	handler := Handler(blog, s.BlogRoot.AsOption(), s.Logger.AsOption())
 
 	// Apply middleware stack if configured
 	if len(s.middleware) > 0 {


### PR DESCRIPTION
Drop the positional *slog.Logger parameter from server.New and server.Handler, completing the Phase 2 cleanup planned in #52. Callers now supply a logger exclusively via config.WithLogger; the fallback to slog.Default() is retained when no option is provided.

All internal call sites, tests, doc examples, and README updated. The Phase-1 deprecated-path tests are removed.

BREAKING CHANGE: server.New(logger, posts, cfg) is now server.New(posts, cfg); server.Handler(blog, logger, opts...) is now server.Handler(blog, opts...).

Closes #55
<!--- START AUTOGENERATED NOTES --->
### Changelog ([#71](https://github.com/harrydayexe/GoBlog/pull/71))

#### ❓ Uncategorised!
- feat(server)!: remove deprecated positional logger from New and Handler

<!--- END AUTOGENERATED NOTES --->