### PR TITLE
feat(server): add health-check endpoints for containerised deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,5 @@ RUN mkdir -p /posts
 EXPOSE 8080
 
 # Use ENTRYPOINT for the binary, CMD for default args
-ENTRYPOINT ["./goblog", "serve"]
+ENTRYPOINT ["./goblog", "serve", "--health-checks"]
 CMD ["/posts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ RUN mkdir -p /posts
 # Expose default port
 EXPOSE 8080
 
+# Healthchecks
+HEALTHCHECK CMD wget --spider -q http://localhost:8080/healthz/startup || exit 1
+
 # Use ENTRYPOINT for the binary, CMD for default args
 ENTRYPOINT ["./goblog", "serve", "--health-checks"]
 CMD ["/posts"]

--- a/README.md
+++ b/README.md
@@ -45,16 +45,25 @@ goblog serve posts/
 | `--root-path` | `-p` | `/` | Blog root path for subdirectory deployment |
 | `--template-dir` | `-t` | built-in | Path to a custom template directory |
 | `--watch` | `-w` | `false` | Watch the posts directory and regenerate on changes |
+| `--health-checks` | | `false` | Expose `/healthz/live`, `/healthz/ready`, and `/healthz/startup` endpoints (no auth required); server binds before loading content so probes observe startup state |
 
 ## Docker
 
-The official image is [`harrydayexe/goblog`](https://hub.docker.com/repository/docker/harrydayexe/goblog/general). It runs `goblog serve /posts` by default and exposes port `8080`. File watching is off by default; pass `--watch` to enable it.
+The official image is [`harrydayexe/goblog`](https://hub.docker.com/repository/docker/harrydayexe/goblog/general). It runs `goblog serve --health-checks /posts` by default and exposes port `8080`. Health-check endpoints are enabled in the Docker image. File watching is off by default; pass `--watch` to enable it.
 
 Mount your Markdown posts directory to `/posts`:
 
 ```bash
 docker run -v ./posts:/posts -p 8080:8080 harrydayexe/goblog
 ```
+
+The image exposes three health-check endpoints that require no authentication:
+
+| Endpoint | Purpose | Response |
+|---|---|---|
+| `GET /healthz/live` | Liveness probe | `200 ok` (always) |
+| `GET /healthz/ready` | Readiness probe | `200 ok` once posts are loaded; `503` while starting or on error |
+| `GET /healthz/startup` | Startup probe | Same semantics as `/healthz/ready` |
 
 To watch for post changes and reload automatically:
 

--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -62,5 +62,10 @@ var ServeCommand cli.Command = cli.Command{
 			Usage:   "watch the posts directory and regenerate the blog on changes",
 			Value:   false,
 		},
+		&cli.BoolFlag{
+			Name:  HealthChecksFlagName,
+			Usage: "expose /healthz/live, /healthz/ready, and /healthz/startup endpoints (no auth required); the server binds before loading content so probes observe startup state",
+			Value: false,
+		},
 	},
 }

--- a/internal/server/flagConsts.go
+++ b/internal/server/flagConsts.go
@@ -27,3 +27,6 @@ const DisableReadingTimeFlagName = "disable-reading-time"
 
 // WatchFlagName is the CLI flag name for enabling filesystem watching.
 const WatchFlagName = "watch"
+
+// HealthChecksFlagName is the CLI flag name for enabling health-check endpoints.
+const HealthChecksFlagName = "health-checks"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,8 +23,13 @@ import (
 
 // NewServeCommand handles the serve command by starting an HTTP server from a directory of markdown posts.
 func NewServeCommand(ctx context.Context, c *cli.Command) error {
+	healthChecksEnabled := c.Bool(HealthChecksFlagName)
+
 	inputPostsDir := c.StringArg(InputPostsDirArgName)
-	inputPostsDir, err := utilities.GetDirectoryFromInput(inputPostsDir, false)
+	// When health checks are enabled the posts directory may not exist yet
+	// (e.g. the volume is not mounted). Allow a non-existent path so the server
+	// can start and surface the failure via /healthz/ready rather than exiting.
+	inputPostsDir, err := utilities.GetDirectoryFromInput(inputPostsDir, healthChecksEnabled)
 	if err != nil {
 		return err
 	}
@@ -80,6 +85,11 @@ func NewServeCommand(ctx context.Context, c *cli.Command) error {
 	}
 
 	cfg.Server = append(cfg.Server, config.WithLogger(slog.Default()).AsServerOption())
+
+	if healthChecksEnabled {
+		cfg.Server = append(cfg.Server, config.WithHealthChecks())
+	}
+
 	return runServe(ctx, inputPostsDir, postsFsys, cfg, c.Bool(WatchFlagName))
 }
 

--- a/justfile
+++ b/justfile
@@ -148,3 +148,8 @@ docker tag="goblog:latest":
     @echo "Building Docker image..."
     docker build -t {{tag}} .
     @echo "✓ Docker image built successfully"
+
+[group("run")]
+run-image tag="goblog:latest": docker
+    @echo "Running Docker image..."
+    docker run -v ./docs/example-posts/:/posts -p 8080:8080 {{tag}}

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -82,6 +82,15 @@
 // later values overwriting earlier ones for duplicate keys. The field is nil
 // when no WithCustomData option is supplied.
 //
+// WithHealthChecks() is a BaseServerOption that enables health-check endpoints
+// on the HTTP server. When enabled, GET /healthz/live always returns 200 OK,
+// while GET /healthz/ready and GET /healthz/startup return 200 OK once posts
+// and templates have loaded and 503 Service Unavailable while starting up or
+// after a load failure. The endpoints require no authentication and are served
+// before the middleware stack. The server binds the HTTP listener before
+// initialising content so probes can observe the startup state. Health checks
+// are disabled by default; the Docker image enables them via --health-checks.
+//
 // # Option types
 //
 // GeneratorOption carries options for generator.New and outputter.NewDirectoryWriter,
@@ -89,7 +98,7 @@
 // WithEnvironment, WithCustomData, WithHTMLPaths, and (via the embedded BaseOption)
 // WithLogger and WithBlogRoot.
 // BaseServerOption carries options for the HTTP server (port, host, middleware,
-// and via the embedded BaseOption: WithLogger, WithBlogRoot).
+// health-check endpoints, and via the embedded BaseOption: WithLogger, WithBlogRoot).
 // WatcherOption carries options for watcher.New (debounce, and via the embedded
 // BaseOption: WithLogger, WithBlogRoot).
 // RendererOption carries options for generator.NewTemplateRenderer (custom funcs).

--- a/pkg/config/serverOption.go
+++ b/pkg/config/serverOption.go
@@ -11,14 +11,15 @@ import "github.com/harrydayexe/GoWebUtilities/middleware"
 // pointer that modifies a specific server setting.
 //
 // This type should not be constructed directly. Use the provided option
-// functions: [WithPort], [WithHost], [WithMiddleware], or call
-// [BaseOption.AsServerOption] on a [BaseOption] value (e.g. from [WithLogger]).
+// functions: [WithPort], [WithHost], [WithMiddleware], [WithHealthChecks], or
+// call [BaseOption.AsServerOption] on a [BaseOption] value (e.g. from [WithLogger]).
 type BaseServerOption struct {
 	BaseOption
 
-	WithPortFunc       func(v *Port)
-	WithHostFunc       func(v *Host)
-	WithMiddlewareFunc func(mw *[]middleware.Middleware)
+	WithPortFunc         func(v *Port)
+	WithHostFunc         func(v *Host)
+	WithMiddlewareFunc   func(mw *[]middleware.Middleware)
+	WithHealthChecksFunc func(v *HealthChecks)
 }
 
 // Port is the TCP port number the HTTP server listens on.
@@ -97,5 +98,47 @@ func WithMiddleware(mw ...middleware.Middleware) BaseServerOption {
 func (o BaseOption) AsServerOption() BaseServerOption {
 	return BaseServerOption{
 		BaseOption: o,
+	}
+}
+
+// HealthChecks is a configuration type that controls whether the HTTP server
+// exposes health-check endpoints at /healthz/live, /healthz/ready, and
+// /healthz/startup.
+//
+// When Enabled is true, the server binds the HTTP listener before loading posts
+// and templates, so liveness/readiness/startup probes can reach the endpoints
+// during startup. Health checks are disabled by default; the Docker image
+// enables them via the --health-checks flag.
+//
+// This type is typically embedded in the server struct and set via [WithHealthChecks].
+type HealthChecks struct{ Enabled bool }
+
+// WithHealthChecks returns a [BaseServerOption] that enables health-check
+// endpoints on the HTTP server.
+//
+// When enabled, the server exposes three unauthenticated endpoints:
+//   - GET /healthz/live    — always 200 OK (process is alive)
+//   - GET /healthz/ready   — 200 OK once posts and templates have loaded;
+//     503 Service Unavailable while starting up or if loading failed
+//   - GET /healthz/startup — same semantics as /healthz/ready
+//
+// The server binds the HTTP listener before initialising content when health
+// checks are enabled, allowing probes to observe the startup state. Response
+// bodies are plain text ("ok" or an error description).
+//
+// Health checks are disabled by default.
+//
+// Example usage:
+//
+//	cfg := config.ServerConfig{
+//	    Server: []config.BaseServerOption{
+//	        config.WithHealthChecks(),
+//	    },
+//	}
+func WithHealthChecks() BaseServerOption {
+	return BaseServerOption{
+		WithHealthChecksFunc: func(v *HealthChecks) {
+			v.Enabled = true
+		},
 	}
 }

--- a/pkg/server/doc.go
+++ b/pkg/server/doc.go
@@ -133,6 +133,31 @@
 //	    srv.UpdatePosts(os.DirFS(postsPath), ctx)
 //	})
 //
+// # Health Checks
+//
+// Enable health-check endpoints via config.WithHealthChecks():
+//
+//	cfg := config.ServerConfig{
+//	    Server: []config.BaseServerOption{
+//	        config.WithPort(8080),
+//	        config.WithHealthChecks(),
+//	    },
+//	}
+//	srv, err := server.New(nil, postsFS, cfg)
+//
+// Three unauthenticated GET endpoints are exposed:
+//
+//   - /healthz/live   — always 200 OK ("ok"); confirms the process is alive.
+//   - /healthz/ready  — 200 OK once posts and templates have loaded; 503 while
+//     starting up or if loading failed (body includes the reason).
+//   - /healthz/startup — same semantics as /healthz/ready; used as the
+//     startup probe in Kubernetes deployments.
+//
+// When health checks are enabled the server binds the HTTP listener before
+// loading posts, so probes can observe startup state. The endpoints bypass
+// middleware (including authentication) and are intercepted in ServeHTTP before
+// the content handler. The Docker image enables health checks by default.
+//
 // # Concurrency
 //
 // All Server methods are safe for concurrent use by multiple goroutines.

--- a/pkg/server/health_test.go
+++ b/pkg/server/health_test.go
@@ -1,0 +1,314 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package server_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/harrydayexe/GoBlog/v2/pkg/config"
+	"github.com/harrydayexe/GoBlog/v2/pkg/server"
+	"github.com/harrydayexe/GoWebUtilities/middleware"
+)
+
+// TestHealthChecks_Disabled verifies that the three /healthz/* endpoints are
+// NOT intercepted when health checks are not enabled; they fall through to the
+// content mux and return 404.
+func TestHealthChecks_Disabled(t *testing.T) {
+	t.Parallel()
+
+	postsFS := createTestFS(t)
+	cfg := config.ServerConfig{
+		Server: []config.BaseServerOption{config.WithPort(8080)},
+	}
+	srv, err := server.New(nil, postsFS, cfg)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	for _, path := range []string{"/healthz/live", "/healthz/ready", "/healthz/startup"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("health checks disabled: GET %s → %d, want 404", path, w.Code)
+		}
+	}
+}
+
+// TestHealthChecks_Live_AlwaysOK verifies that /healthz/live returns 200 OK
+// even while the server is still in the starting state (before Run is called).
+func TestHealthChecks_Live_AlwaysOK(t *testing.T) {
+	t.Parallel()
+
+	postsFS := createTestFS(t)
+	cfg := config.ServerConfig{
+		Server: []config.BaseServerOption{
+			config.WithPort(8080),
+			config.WithHealthChecks(),
+		},
+	}
+	// New returns immediately with state=starting when health checks are on.
+	srv, err := server.New(nil, postsFS, cfg)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz/live", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("/healthz/live: got %d, want 200", w.Code)
+	}
+	if got := strings.TrimSpace(w.Body.String()); got != "ok" {
+		t.Errorf("/healthz/live body: got %q, want \"ok\"", got)
+	}
+}
+
+// TestHealthChecks_Ready_WhileStarting verifies that /healthz/ready and
+// /healthz/startup return 503 before content has been loaded.
+func TestHealthChecks_Ready_WhileStarting(t *testing.T) {
+	t.Parallel()
+
+	postsFS := createTestFS(t)
+	cfg := config.ServerConfig{
+		Server: []config.BaseServerOption{
+			config.WithPort(8080),
+			config.WithHealthChecks(),
+		},
+	}
+	// State is "starting" immediately after New (before Run).
+	srv, err := server.New(nil, postsFS, cfg)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	for _, path := range []string{"/healthz/ready", "/healthz/startup"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+
+		if w.Code != http.StatusServiceUnavailable {
+			t.Errorf("GET %s while starting: got %d, want 503", path, w.Code)
+		}
+		body := strings.TrimSpace(w.Body.String())
+		if body == "" {
+			t.Errorf("GET %s while starting: body is empty, want a reason string", path)
+		}
+	}
+}
+
+// TestHealthChecks_NonGetMethod verifies that all three endpoints return
+// 405 Method Not Allowed for non-GET methods.
+func TestHealthChecks_NonGetMethod(t *testing.T) {
+	t.Parallel()
+
+	postsFS := createTestFS(t)
+	cfg := config.ServerConfig{
+		Server: []config.BaseServerOption{
+			config.WithPort(8080),
+			config.WithHealthChecks(),
+		},
+	}
+	srv, err := server.New(nil, postsFS, cfg)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	methods := []string{http.MethodPost, http.MethodPut, http.MethodDelete}
+	paths := []string{"/healthz/live", "/healthz/ready", "/healthz/startup"}
+
+	for _, method := range methods {
+		for _, path := range paths {
+			req := httptest.NewRequest(method, path, nil)
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, req)
+
+			if w.Code != http.StatusMethodNotAllowed {
+				t.Errorf("%s %s: got %d, want 405", method, path, w.Code)
+			}
+		}
+	}
+}
+
+// TestHealthChecks_BypassesMiddleware verifies that /healthz/live returns
+// 200 OK even when a middleware that rejects all requests is configured.
+// This confirms that health endpoints are served before the middleware stack.
+func TestHealthChecks_BypassesMiddleware(t *testing.T) {
+	t.Parallel()
+
+	rejectAll := middleware.Middleware(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+		})
+	})
+
+	postsFS := createTestFS(t)
+	cfg := config.ServerConfig{
+		Server: []config.BaseServerOption{
+			config.WithPort(8080),
+			config.WithMiddleware(rejectAll),
+			config.WithHealthChecks(),
+		},
+	}
+	// With health checks disabled the sync path is used (middleware is applied
+	// but health routes are not intercepted). Enable health checks to get the
+	// pre-middleware interception.
+	srv, err := server.New(nil, postsFS, cfg)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz/live", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("/healthz/live with rejecting middleware: got %d, want 200", w.Code)
+	}
+}
+
+// TestHealthChecks_ReadyAfterInit verifies that /healthz/ready returns 200 OK
+// after Run has completed content initialisation. This requires a real HTTP
+// listener so we poll until the probe responds 200 or a timeout is reached.
+func TestHealthChecks_ReadyAfterInit(t *testing.T) {
+	t.Parallel()
+
+	postsFS := createTestFS(t)
+
+	// Grab a free port.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+
+	cfg := config.ServerConfig{
+		Server: []config.BaseServerOption{
+			config.WithPort(port),
+			config.WithHost("127.0.0.1"),
+			config.WithHealthChecks(),
+		},
+	}
+	srv, err := server.New(nil, postsFS, cfg)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- srv.Run(ctx) }()
+
+	addr := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// Poll /healthz/ready until 200 or timeout.
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(addr + "/healthz/ready") //nolint:noctx
+		if err == nil {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				if got := strings.TrimSpace(string(body)); got != "ok" {
+					t.Errorf("/healthz/ready body: got %q, want \"ok\"", got)
+				}
+				cancel() // graceful shutdown
+				return
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	t.Error("/healthz/ready did not return 200 within the deadline")
+	cancel()
+}
+
+// TestHealthChecks_FailedInit verifies that /healthz/ready returns 503 with a
+// non-empty reason when content initialisation fails (e.g. unreadable FS).
+func TestHealthChecks_FailedInit(t *testing.T) {
+	t.Parallel()
+
+	// errFS always returns an error on Open, causing generator.Generate to fail.
+	brokenFS := fstest.MapFS{
+		"broken.md": &fstest.MapFile{
+			// Frontmatter is deliberately malformed to trigger a parse error.
+			Data: []byte("---\nbad yaml: [unclosed\n---\n# hello\n"),
+		},
+	}
+
+	// Grab a free port.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+
+	cfg := config.ServerConfig{
+		Server: []config.BaseServerOption{
+			config.WithPort(port),
+			config.WithHost("127.0.0.1"),
+			config.WithHealthChecks(),
+		},
+	}
+	srv, err := server.New(nil, brokenFS, cfg)
+	if err != nil {
+		t.Fatalf("server.New: %v (want nil when health checks enabled)", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	go func() { srv.Run(ctx) }() //nolint:errcheck
+
+	addr := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// Poll until we get either a 503 (failed) or timeout.
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(addr + "/healthz/ready") //nolint:noctx
+		if err != nil {
+			time.Sleep(25 * time.Millisecond)
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		switch resp.StatusCode {
+		case http.StatusServiceUnavailable:
+			// Good — check that a reason is included.
+			bodyStr := strings.TrimSpace(string(body))
+			if bodyStr == "" || bodyStr == "starting" {
+				// Still starting; keep polling.
+				time.Sleep(25 * time.Millisecond)
+				continue
+			}
+			// Got a failure reason. Test passes.
+			cancel()
+			return
+		case http.StatusOK:
+			t.Error("/healthz/ready returned 200 even with a broken FS")
+			cancel()
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	t.Error("/healthz/ready did not return 503 with a failure reason within the deadline")
+	cancel()
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,6 +23,22 @@ import (
 	"github.com/harrydayexe/GoWebUtilities/middleware"
 )
 
+// probeState describes the current lifecycle state of the server, used to
+// answer health-check probes.
+type probeState int
+
+const (
+	probeStarting probeState = iota // server is binding and loading content
+	probeReady                      // content loaded, ready to serve traffic
+	probeFailed                     // content loading failed; see healthStatus.reason
+)
+
+// healthStatus is stored atomically and read by serveHealth.
+type healthStatus struct {
+	state  probeState
+	reason string // non-empty when state == probeFailed
+}
+
 // Server is an HTTP server that serves generated blog content with support
 // for live content updates.
 //
@@ -34,19 +50,33 @@ import (
 // Server implements http.Handler interface, delegating requests to the current
 // handler loaded atomically.
 //
+// When health checks are enabled via [config.WithHealthChecks], the server
+// binds the HTTP listener before loading posts and templates. The three
+// health-check endpoints (/healthz/live, /healthz/ready, /healthz/startup) are
+// intercepted before the middleware stack and always available without auth.
+//
 // All methods are safe for concurrent use by multiple goroutines.
 type Server struct {
-	mu       sync.RWMutex // protects postsDir and generator during refreshHandler
+	// mu protects postsDir, generator, and generator fields during initialize
+	// and refreshHandler.
+	mu       sync.RWMutex
 	postsDir fs.FS
 
 	config.BlogRoot
 	config.Port
 	config.Host
 	config.Logger
+	config.HealthChecks
 
-	handler    atomic.Value            // stores http.Handler
+	handler    atomic.Value // stores http.Handler
+	health     atomic.Pointer[healthStatus]
 	middleware []middleware.Middleware // middleware chain
 	generator  *generator.Generator
+
+	// deferred initialisation inputs — set in New, consumed by initialize.
+	templatesDir fs.FS
+	rendererOpts []config.RendererOption
+	genOpts      []config.GeneratorOption
 }
 
 // New creates a new Server instance with the specified configuration.
@@ -54,11 +84,20 @@ type Server struct {
 // The posts filesystem contains the markdown blog posts to be served.
 // The opts parameter configures server behavior via the functional options pattern.
 //
-// New initializes the server's HTTP handler by generating blog content from
-// the posts filesystem. If initial generation fails, an error is returned.
+// When health checks are disabled (the default), New initializes the server's
+// HTTP handler synchronously by generating blog content from the posts
+// filesystem. If initial generation fails, an error is returned and the server
+// is not started.
 //
-// Returns an error if template rendering or initial blog generation fails.
-// The server is ready to serve requests immediately upon successful return.
+// When health checks are enabled via [config.WithHealthChecks], New skips
+// content generation and returns immediately. The HTTP handler is initialized
+// asynchronously when [Run] is called, so probes can observe the startup state
+// via /healthz/ready and /healthz/startup. In this mode New does not return an
+// error on content-loading failures; instead, the failure is surfaced through
+// the /healthz/ready endpoint.
+//
+// Returns an error if template rendering or initial blog generation fails (only
+// in the synchronous / health-checks-disabled path).
 //
 // # Logger
 //
@@ -86,6 +125,8 @@ func New(logger *slog.Logger, posts fs.FS, opts config.ServerConfig) (*Server, e
 			opt.WithMiddlewareFunc(&srv.middleware)
 		} else if opt.WithLoggerFunc != nil {
 			opt.WithLoggerFunc(&srv.Logger)
+		} else if opt.WithHealthChecksFunc != nil {
+			opt.WithHealthChecksFunc(&srv.HealthChecks)
 		}
 	}
 
@@ -98,6 +139,7 @@ func New(logger *slog.Logger, posts fs.FS, opts config.ServerConfig) (*Server, e
 		}
 	}
 
+	// Resolve the template filesystem.
 	var templatesDir fs.FS
 	if opts.TemplateDir != nil {
 		srv.Logger.Logger.Debug("Using custom templates")
@@ -107,33 +149,67 @@ func New(logger *slog.Logger, posts fs.FS, opts config.ServerConfig) (*Server, e
 		templatesDir = templates.Default
 	}
 
-	renderer, err := generator.NewTemplateRenderer(templatesDir, opts.RendererOpts...)
-	if err != nil {
-		return nil, err
-	}
-
-	// Propagate the server's resolved logger into the generator.
+	// Build the generator option slice (merging caller options with logger).
 	genOpts := make([]config.GeneratorOption, 0, len(opts.Gen)+1)
 	genOpts = append(genOpts, opts.Gen...)
 	genOpts = append(genOpts, srv.Logger.AsOption().AsGeneratorOption())
-	gen := generator.New(posts, renderer, genOpts...)
-	srv.generator = gen
 
-	// Sync the resolved BlogRoot to the generator so rendered links use the correct prefix.
-	gen.BlogRoot = srv.BlogRoot
+	// Store inputs needed by initialize (both sync and async paths use them).
+	srv.templatesDir = templatesDir
+	srv.rendererOpts = opts.RendererOpts
+	srv.genOpts = genOpts
 
-	// Initialize handler before returning. Server is not yet published so no lock needed.
-	if err := srv.refreshHandler(context.Background()); err != nil {
-		return nil, fmt.Errorf("failed to initialize handler: %w", err)
+	if srv.HealthChecks.Enabled {
+		// Async path: bind first, generate in Run. Mark as starting.
+		srv.health.Store(&healthStatus{state: probeStarting})
+		srv.Logger.Logger.Debug("Health checks enabled: deferring content initialisation to Run")
+		return srv, nil
+	}
+
+	// Sync path (default): initialize before returning, same behaviour as before.
+	if err := srv.initialize(context.Background()); err != nil {
+		return nil, err
 	}
 
 	srv.Logger.Logger.Debug("Server created successfully")
 	return srv, nil
 }
 
+// initialize builds the template renderer and generator, generates the initial
+// blog content, and stores the HTTP handler atomically.
+//
+// Callers from New (sync path) invoke this before the server is published, so
+// no lock is needed for the struct itself. Callers from Run (async path) invoke
+// this concurrently with an already-published server, so the critical section
+// that touches s.generator and calls refreshHandler is protected by s.mu.
+func (s *Server) initialize(ctx context.Context) error {
+	renderer, err := generator.NewTemplateRenderer(s.templatesDir, s.rendererOpts...)
+	if err != nil {
+		return fmt.Errorf("failed to create template renderer: %w", err)
+	}
+
+	s.mu.Lock()
+	posts := s.postsDir
+	gen := generator.New(posts, renderer, s.genOpts...)
+	s.generator = gen
+	s.generator.BlogRoot = s.BlogRoot
+	err = s.refreshHandler(ctx)
+	s.mu.Unlock()
+
+	if err != nil {
+		return fmt.Errorf("failed to initialize handler: %w", err)
+	}
+	return nil
+}
+
 // ServeHTTP implements http.Handler, delegating requests to the current handler.
 // The handler is loaded atomically, allowing it to be safely updated via
 // UpdatePosts while requests are being served.
+//
+// When health checks are enabled, ServeHTTP intercepts requests to
+// /healthz/live, /healthz/ready, and /healthz/startup before the middleware
+// stack, so they are always reachable without authentication and during async
+// startup.
 //
 // ServeHTTP is safe for concurrent use by multiple goroutines. It performs
 // a lock-free atomic load of the current handler on each request.
@@ -141,6 +217,14 @@ func New(logger *slog.Logger, posts fs.FS, opts config.ServerConfig) (*Server, e
 // If the handler has not been initialized (nil), ServeHTTP returns a
 // 503 Service Unavailable error.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.HealthChecks.Enabled {
+		switch r.URL.Path {
+		case "/healthz/live", "/healthz/ready", "/healthz/startup":
+			s.serveHealth(w, r)
+			return
+		}
+	}
+
 	h := s.handler.Load()
 	if h == nil {
 		s.Logger.Logger.ErrorContext(r.Context(), "handler not initialized")
@@ -150,9 +234,46 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.(http.Handler).ServeHTTP(w, r)
 }
 
+// serveHealth handles requests to the /healthz/* endpoints.
+// Only GET is accepted; any other method returns 405 Method Not Allowed.
+//
+// /healthz/live always returns 200 OK.
+// /healthz/ready and /healthz/startup return 200 OK once content has loaded
+// and 503 Service Unavailable while starting or after a load failure.
+func (s *Server) serveHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	switch r.URL.Path {
+	case "/healthz/live":
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		fmt.Fprint(w, "ok")
+
+	case "/healthz/ready", "/healthz/startup":
+		st := s.health.Load()
+		if st == nil || st.state != probeReady {
+			reason := "starting"
+			if st != nil && st.state == probeFailed {
+				reason = "not ready: " + st.reason
+			}
+			http.Error(w, reason, http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		fmt.Fprint(w, "ok")
+	}
+}
+
 // Run starts the HTTP server and blocks until interrupted via context cancellation
 // or OS signal (SIGINT, SIGTERM, SIGHUP). It handles graceful shutdown with a
 // 10-second timeout.
+//
+// When health checks are enabled, Run launches content initialisation in a
+// background goroutine so that the HTTP listener is available immediately for
+// probe traffic. The /healthz/ready and /healthz/startup endpoints return
+// 503 until initialisation completes (or 503 with a reason if it fails).
 //
 // The server uses atomic handler swapping, allowing UpdatePosts to be called
 // while the server is running without interrupting in-flight requests.
@@ -172,6 +293,20 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	var wg sync.WaitGroup
+
+	// When health checks are enabled, initialize content asynchronously so the
+	// listener binds immediately and probes can reach /healthz/* during startup.
+	if s.HealthChecks.Enabled {
+		wg.Go(func() {
+			if err := s.initialize(ctx); err != nil {
+				s.health.Store(&healthStatus{state: probeFailed, reason: err.Error()})
+				s.Logger.Logger.ErrorContext(ctx, "async content initialisation failed", slog.Any("error", err))
+				return
+			}
+			s.health.Store(&healthStatus{state: probeReady})
+			s.Logger.Logger.DebugContext(ctx, "async content initialisation complete")
+		})
+	}
 
 	// Track ListenAndServe goroutine. On bind/listen failure, cancel ctx so the
 	// shutdown goroutine wakes and wg.Wait() can return.
@@ -211,16 +346,32 @@ func (s *Server) Run(ctx context.Context) error {
 // The handler swap is atomic, ensuring that requests see either the old or new
 // content without any intermediate inconsistent state.
 //
+// If the server has not yet completed its initial content load (health-checks
+// async path), UpdatePosts returns an error immediately rather than racing with
+// the initialisation goroutine.
+//
 // If handler refresh fails, an error is returned and the previous handler
 // remains active, continuing to serve the old content.
 func (s *Server) UpdatePosts(posts fs.FS, ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if s.generator == nil {
+		return fmt.Errorf("server not yet initialised; cannot update posts before initial content load completes")
+	}
+
 	s.postsDir = posts
 	s.generator.PostsDir = posts
 	if err := s.refreshHandler(ctx); err != nil {
 		return fmt.Errorf("failed to refresh handler: %w", err)
 	}
+
+	// Recover health state after a successful reload (e.g. after a prior failure
+	// in watch mode). Only meaningful when health checks are enabled.
+	if s.HealthChecks.Enabled {
+		s.health.Store(&healthStatus{state: probeReady})
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Enables /healthz/live, /healthz/ready, and /healthz/startup probes via --health-checks (off by default, on in the Docker image). The server binds the HTTP listener before loading posts and templates when health checks are on, so probes can observe startup state and surface volume failures as 503 rather than a process exit. Endpoints bypass the middleware stack and require no authentication.
<!--- START AUTOGENERATED NOTES --->
### Changelog ([#74](https://github.com/harrydayexe/GoBlog/pull/74))

#### ✨ New Features
- (server) add health-check endpoints for containerised deployments
- (docker) add HEALTHCHECK to image

<!--- END AUTOGENERATED NOTES --->